### PR TITLE
Add reusable GitHub issue templates + install script

### DIFF
--- a/install-issue-templates.py
+++ b/install-issue-templates.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Install GitHub issue templates into a target repository."""
+
+import argparse
+import shutil
+from pathlib import Path
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Install issue templates into a repo")
+    parser.add_argument("target", help="Path to the target repository")
+    parser.add_argument("--force", action="store_true", help="Overwrite existing templates")
+    args = parser.parse_args()
+
+    target = Path(args.target).resolve()
+    if not (target / ".git").exists():
+        print(f"Error: {target} is not a git repository")
+        return 1
+
+    source = Path(__file__).parent / "templates" / "issue-templates"
+    dest = target / ".github" / "ISSUE_TEMPLATE"
+
+    if dest.exists() and not args.force:
+        existing = list(dest.glob("*.yml"))
+        if existing:
+            print(f"Templates already exist at {dest}:")
+            for f in existing:
+                print(f"  {f.name}")
+            print("Use --force to overwrite")
+            return 1
+
+    dest.mkdir(parents=True, exist_ok=True)
+
+    installed = []
+    for template in source.glob("*.yml"):
+        shutil.copy2(template, dest / template.name)
+        installed.append(template.name)
+
+    print(f"Installed {len(installed)} templates at {dest}:")
+    for name in sorted(installed):
+        print(f"  {name}")
+    print("\nCommit and push to activate.")
+    return 0
+
+
+if __name__ == "__main__":
+    exit(main())

--- a/templates/issue-templates/bug_report.yml
+++ b/templates/issue-templates/bug_report.yml
@@ -1,0 +1,36 @@
+name: Bug Report
+description: Something is broken
+labels: ["bug"]
+body:
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Clear description of the bug. What did you expect vs what actually happened?
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      description: Minimal steps to trigger the bug
+      value: |
+        1.
+        2.
+        3.
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Browser, OS, Node/Python/PHP version — whatever's relevant
+    validations:
+      required: false
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots / logs
+      description: Paste error messages, console output, or screenshots
+    validations:
+      required: false

--- a/templates/issue-templates/config.yml
+++ b/templates/issue-templates/config.yml
@@ -1,0 +1,2 @@
+blank_issues_enabled: true
+contact_links: []

--- a/templates/issue-templates/feature_request.yml
+++ b/templates/issue-templates/feature_request.yml
@@ -1,0 +1,25 @@
+name: Feature Request
+description: Something should exist
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: what
+    attributes:
+      label: What do you want?
+      description: Describe the feature. What should it do? Why?
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: What problem does this solve? What are you doing today that this would improve?
+    validations:
+      required: false
+  - type: textarea
+    id: approach
+    attributes:
+      label: Possible approach
+      description: If you have ideas on implementation, sketch them here. Not required.
+    validations:
+      required: false

--- a/templates/issue-templates/refactor.yml
+++ b/templates/issue-templates/refactor.yml
@@ -1,0 +1,32 @@
+name: Refactor
+description: Something works but needs to be better
+labels: ["refactor"]
+body:
+  - type: textarea
+    id: what
+    attributes:
+      label: What needs to change?
+      description: Which code, module, or pattern needs rework?
+    validations:
+      required: true
+  - type: textarea
+    id: why
+    attributes:
+      label: Why?
+      description: What's wrong with how it works today? Performance, maintainability, readability, duplication?
+    validations:
+      required: true
+  - type: textarea
+    id: approach
+    attributes:
+      label: Proposed approach
+      description: How should it be restructured?
+    validations:
+      required: false
+  - type: textarea
+    id: risks
+    attributes:
+      label: Risks
+      description: What could break? What depends on the current implementation?
+    validations:
+      required: false

--- a/templates/issue-templates/research.yml
+++ b/templates/issue-templates/research.yml
@@ -1,0 +1,25 @@
+name: Research / Exploration
+description: Something needs investigation before it's actionable
+labels: ["research"]
+body:
+  - type: textarea
+    id: question
+    attributes:
+      label: What are we trying to figure out?
+      description: The core question or hypothesis
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: What do we know so far?
+      description: Observations, prior attempts, relevant screenshots or data
+    validations:
+      required: false
+  - type: textarea
+    id: success
+    attributes:
+      label: What does "answered" look like?
+      description: When is this investigation done? What outcome makes it actionable?
+    validations:
+      required: false


### PR DESCRIPTION
## Summary

- 4 issue templates: bug report, feature request, refactor, research/exploration
- Minimal structure (3-5 fields each) — enough to be useful, not enough to be a chore
- `install-issue-templates.py` copies them into any repo's `.github/ISSUE_TEMPLATE/`
- `config.yml` allows blank issues alongside templates

## Usage
```
python install-issue-templates.py /path/to/repo
python install-issue-templates.py /path/to/repo --force  # overwrite existing
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)