### PR TITLE
Add refactoring assist tools

### DIFF
--- a/count-callers.py
+++ b/count-callers.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""Find all call sites of a function across a codebase.
+
+Usage:
+    python count-callers.py processEscapePath /path/to/project
+    python count-callers.py processEscapePath /path/to/project --type js
+    python count-callers.py processEscapePath /path/to/project --exclude vendor,node_modules
+"""
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+# Default directories to exclude
+DEFAULT_EXCLUDE = {"node_modules", "vendor", ".git", "__pycache__", "dist", "build"}
+
+# File extensions by type
+EXT_MAP = {
+    "js": {".js", ".mjs", ".cjs", ".jsx", ".ts", ".tsx"},
+    "py": {".py"},
+    "php": {".php"},
+    "css": {".css", ".scss", ".less"},
+    "html": {".html", ".htm"},
+}
+
+
+def find_callers(root: Path, func_name: str, extensions: set[str], exclude: set[str]):
+    """Find all references to func_name in files under root."""
+    results = []
+    pattern = re.compile(r'\b' + re.escape(func_name) + r'\b')
+
+    for path in sorted(root.rglob("*")):
+        if not path.is_file():
+            continue
+        if path.suffix not in extensions:
+            continue
+        if any(ex in path.parts for ex in exclude):
+            continue
+
+        try:
+            lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+        except (OSError, UnicodeDecodeError):
+            continue
+
+        for i, line in enumerate(lines):
+            if pattern.search(line):
+                stripped = line.strip()
+                # Classify: definition vs call vs reference
+                kind = classify(stripped, func_name)
+                results.append({
+                    "file": str(path.relative_to(root)),
+                    "line": i + 1,
+                    "kind": kind,
+                    "text": stripped[:120],
+                })
+
+    return results
+
+
+def classify(line: str, func_name: str) -> str:
+    """Classify a line as definition, call, or reference."""
+    # Definition patterns
+    def_patterns = [
+        rf'^\s*"?{re.escape(func_name)}"?\s*\(.*\)\s*\{{',  # funcName(...) {
+        rf'^\s*"?{re.escape(func_name)}"?\s*:\s*function',    # "funcName": function
+        rf'function\s+{re.escape(func_name)}\s*\(',           # function funcName(
+        rf'(const|let|var)\s+{re.escape(func_name)}\s*=',     # const funcName =
+        rf'def\s+{re.escape(func_name)}\s*\(',                # def funcName( (Python)
+    ]
+    for pat in def_patterns:
+        if re.search(pat, line):
+            return "DEF"
+
+    # Comment
+    if line.lstrip().startswith("//") or line.lstrip().startswith("#") or line.lstrip().startswith("/*"):
+        return "COMMENT"
+
+    # Call pattern: funcName( or .funcName(
+    if re.search(rf'\.?{re.escape(func_name)}\s*\(', line):
+        return "CALL"
+
+    return "REF"
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Find all call sites of a function")
+    parser.add_argument("function", help="Function name to search for")
+    parser.add_argument("path", help="Root directory to search")
+    parser.add_argument("--type", help="File type filter: js, py, php, css, html")
+    parser.add_argument("--exclude", help="Comma-separated dirs to exclude (added to defaults)")
+    parser.add_argument("--json", action="store_true", help="JSON output")
+    args = parser.parse_args()
+
+    root = Path(args.path).resolve()
+    if not root.is_dir():
+        print(f"Error: {args.path} is not a directory", file=sys.stderr)
+        return 1
+
+    # Determine extensions
+    if args.type:
+        extensions = EXT_MAP.get(args.type, set())
+        if not extensions:
+            extensions = {f".{args.type}"}
+    else:
+        extensions = set()
+        for exts in EXT_MAP.values():
+            extensions.update(exts)
+
+    exclude = set(DEFAULT_EXCLUDE)
+    if args.exclude:
+        exclude.update(args.exclude.split(","))
+
+    results = find_callers(root, args.function, extensions, exclude)
+
+    if args.json:
+        import json
+        print(json.dumps(results, indent=2))
+        return 0
+
+    # Summary
+    defs = [r for r in results if r["kind"] == "DEF"]
+    calls = [r for r in results if r["kind"] == "CALL"]
+    refs = [r for r in results if r["kind"] == "REF"]
+    comments = [r for r in results if r["kind"] == "COMMENT"]
+
+    print(f"Function: {args.function}")
+    print(f"Found: {len(defs)} definitions, {len(calls)} calls, {len(refs)} references, {len(comments)} comments")
+    print()
+
+    if defs:
+        print("DEFINITIONS:")
+        for r in defs:
+            print(f"  {r['file']}:{r['line']}  {r['text']}")
+        print()
+
+    if calls:
+        print("CALLS:")
+        for r in calls:
+            print(f"  {r['file']}:{r['line']}  {r['text']}")
+        print()
+
+    if refs:
+        print("REFERENCES:")
+        for r in refs:
+            print(f"  {r['file']}:{r['line']}  {r['text']}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/diff-functions.py
+++ b/diff-functions.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Extract and side-by-side diff two named functions from JS files.
+
+Usage:
+    python diff-functions.py file.js funcA funcB
+    python diff-functions.py fileA.js:funcA fileB.js:funcB
+    python diff-functions.py file.js funcA funcB --unified
+"""
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+
+def extract_function(filepath: str, func_name: str) -> tuple[list[str], int]:
+    """Extract a function/method body from a JS file by name.
+
+    Returns (lines, start_line_number).
+    Handles: "funcName"(...) {, funcName(...) {, "funcName": function(
+    """
+    path = Path(filepath)
+    if not path.exists():
+        print(f"Error: {filepath} not found", file=sys.stderr)
+        sys.exit(1)
+
+    lines = path.read_text(encoding="utf-8").splitlines()
+
+    # Patterns to match function definitions
+    patterns = [
+        rf'^\s*"?{re.escape(func_name)}"?\s*\(',           # "funcName"( or funcName(
+        rf'^\s*"?{re.escape(func_name)}"?\s*:\s*function',  # "funcName": function
+        rf'^\s*function\s+{re.escape(func_name)}\s*\(',     # function funcName(
+        rf'^\s*const\s+{re.escape(func_name)}\s*=',         # const funcName =
+        rf'^\s*let\s+{re.escape(func_name)}\s*=',           # let funcName =
+        rf'^\s*var\s+{re.escape(func_name)}\s*=',           # var funcName =
+    ]
+
+    start = None
+    for i, line in enumerate(lines):
+        for pat in patterns:
+            if re.search(pat, line):
+                start = i
+                break
+        if start is not None:
+            break
+
+    if start is None:
+        print(f"Error: function '{func_name}' not found in {filepath}", file=sys.stderr)
+        sys.exit(1)
+
+    # Find the end by tracking brace depth
+    depth = 0
+    found_open = False
+    end = start
+
+    for i in range(start, len(lines)):
+        for ch in lines[i]:
+            if ch == "{":
+                depth += 1
+                found_open = True
+            elif ch == "}":
+                depth -= 1
+        if found_open and depth <= 0:
+            end = i
+            break
+
+    return lines[start : end + 1], start + 1
+
+
+def side_by_side(left: list[str], right: list[str], left_label: str, right_label: str, width: int = 80):
+    """Print two function bodies side by side."""
+    half = width // 2 - 2
+    print(f"{'-' * half}+{'-' * half}")
+    print(f"{left_label:<{half}}|{right_label:<{half}}")
+    print(f"{'-' * half}+{'-' * half}")
+
+    max_len = max(len(left), len(right))
+    for i in range(max_len):
+        l = left[i].rstrip() if i < len(left) else ""
+        r = right[i].rstrip() if i < len(right) else ""
+
+        # Highlight differences
+        marker = " "
+        if i < len(left) and i < len(right):
+            if l.strip() != r.strip():
+                marker = "!"
+            elif l.strip() == r.strip() and l.strip():
+                marker = " "
+        elif i >= len(left) or i >= len(right):
+            marker = "+"
+
+        l_display = l[:half - 1]
+        r_display = r[:half - 1]
+        print(f"{l_display:<{half}}{marker}{r_display}")
+
+    print(f"{'-' * half}+{'-' * half}")
+
+
+def unified_diff(left: list[str], right: list[str], left_label: str, right_label: str):
+    """Print unified diff."""
+    import difflib
+    diff = difflib.unified_diff(
+        left, right,
+        fromfile=left_label, tofile=right_label,
+        lineterm=""
+    )
+    for line in diff:
+        print(line)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Extract and diff two JS functions")
+    parser.add_argument("source1", help="file.js:funcName or just file.js")
+    parser.add_argument("source2", help="funcName (if file shared) or file.js:funcName")
+    parser.add_argument("func2", nargs="?", help="Second function name (if both in same file)")
+    parser.add_argument("--unified", "-u", action="store_true", help="Unified diff instead of side-by-side")
+    parser.add_argument("--width", "-w", type=int, default=160, help="Terminal width for side-by-side")
+    parser.add_argument("--stats", action="store_true", help="Show similarity statistics")
+    args = parser.parse_args()
+
+    # Parse source arguments
+    if args.func2:
+        # diff-functions.py file.js funcA funcB
+        file1 = file2 = args.source1
+        func1 = args.source2
+        func2 = args.func2
+    elif ":" in args.source1:
+        # diff-functions.py fileA.js:funcA fileB.js:funcB
+        file1, func1 = args.source1.rsplit(":", 1)
+        file2, func2 = args.source2.rsplit(":", 1)
+    else:
+        parser.error("Provide file.js funcA funcB, or fileA.js:funcA fileB.js:funcB")
+        return 1
+
+    left, left_start = extract_function(file1, func1)
+    right, right_start = extract_function(file2, func2)
+
+    left_label = f"{Path(file1).name}:{func1} (line {left_start})"
+    right_label = f"{Path(file2).name}:{func2} (line {right_start})"
+
+    if args.stats:
+        import difflib
+        ratio = difflib.SequenceMatcher(
+            None,
+            [l.strip() for l in left],
+            [r.strip() for r in right]
+        ).ratio()
+        print(f"\n{left_label}: {len(left)} lines")
+        print(f"{right_label}: {len(right)} lines")
+        print(f"Similarity: {ratio:.1%}")
+        print()
+
+    if args.unified:
+        unified_diff(left, right, left_label, right_label)
+    else:
+        side_by_side(left, right, left_label, right_label, args.width)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/gh-comment.py
+++ b/gh-comment.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""Post a templated comment on a GitHub issue or PR.
+
+Usage:
+    python gh-comment.py --repo jparish1977/mandelbrotexplorer --issue 3 --template closing \\
+        --var pr_number=33 \\
+        --var summary="Hair now supports color cycling via shared processEscapePathShared" \\
+        --var file_list="cloudGeneration.js, mandelbrotexplorer.js" \\
+        --var verification_steps="Generate Hair, toggle Color Cycle checkbox"
+
+    python gh-comment.py --repo jparish1977/mandelbrotexplorer --issue 4 --template superseded \\
+        --var new_issue_number=15 \\
+        --var reason="GPU shader approach is orders of magnitude faster than web workers"
+
+    # Preview without posting:
+    python gh-comment.py --template spec --var goal="Add Julia mode" --dry-run
+
+    # List available templates:
+    python gh-comment.py --list
+"""
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+
+TEMPLATE_DIR = Path(__file__).parent / "templates" / "comment-templates"
+
+
+def list_templates():
+    """List available comment templates."""
+    if not TEMPLATE_DIR.exists():
+        print("No templates found", file=sys.stderr)
+        return
+
+    for f in sorted(TEMPLATE_DIR.glob("*.md")):
+        name = f.stem
+        # Read first non-empty line as description
+        first_line = ""
+        for line in f.read_text(encoding="utf-8").splitlines():
+            stripped = line.strip().lstrip("#").strip()
+            if stripped:
+                first_line = stripped
+                break
+        print(f"  {name:20s} {first_line}")
+
+
+def fill_template(template_name: str, variables: dict) -> str:
+    """Fill a template with variables."""
+    template_path = TEMPLATE_DIR / f"{template_name}.md"
+    if not template_path.exists():
+        # Try partial match
+        matches = list(TEMPLATE_DIR.glob(f"*{template_name}*.md"))
+        if len(matches) == 1:
+            template_path = matches[0]
+        elif len(matches) > 1:
+            print(f"Ambiguous template '{template_name}'. Matches:", file=sys.stderr)
+            for m in matches:
+                print(f"  {m.stem}", file=sys.stderr)
+            sys.exit(1)
+        else:
+            print(f"Template '{template_name}' not found. Use --list to see available.", file=sys.stderr)
+            sys.exit(1)
+
+    content = template_path.read_text(encoding="utf-8")
+
+    for key, value in variables.items():
+        content = content.replace(f"{{{key}}}", value)
+
+    # Warn about unfilled placeholders
+    import re
+    unfilled = re.findall(r'\{(\w+)\}', content)
+    if unfilled:
+        print(f"Warning: unfilled placeholders: {', '.join(unfilled)}", file=sys.stderr)
+
+    return content
+
+
+def post_comment(repo: str, issue_number: int, body: str):
+    """Post a comment via gh CLI."""
+    result = subprocess.run(
+        ["gh", "issue", "comment", str(issue_number),
+         "--repo", repo,
+         "--body", body],
+        capture_output=True, text=True
+    )
+    if result.returncode != 0:
+        print(f"Error posting comment: {result.stderr}", file=sys.stderr)
+        sys.exit(1)
+    print(result.stdout.strip())
+
+
+def close_issue(repo: str, issue_number: int):
+    """Close an issue via gh CLI."""
+    result = subprocess.run(
+        ["gh", "issue", "close", str(issue_number), "--repo", repo],
+        capture_output=True, text=True
+    )
+    if result.returncode != 0:
+        print(f"Error closing issue: {result.stderr}", file=sys.stderr)
+    else:
+        print(f"Closed #{issue_number}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Post templated GitHub comments")
+    parser.add_argument("--repo", help="owner/repo")
+    parser.add_argument("--issue", type=int, help="Issue or PR number")
+    parser.add_argument("--template", "-t", help="Template name")
+    parser.add_argument("--var", action="append", default=[], help="key=value pairs")
+    parser.add_argument("--dry-run", action="store_true", help="Preview without posting")
+    parser.add_argument("--close", action="store_true", help="Also close the issue after commenting")
+    parser.add_argument("--list", action="store_true", help="List available templates")
+    args = parser.parse_args()
+
+    if args.list:
+        list_templates()
+        return 0
+
+    if not args.template:
+        parser.error("--template is required (or use --list)")
+
+    # Parse variables
+    variables = {}
+    for var in args.var:
+        if "=" not in var:
+            parser.error(f"Invalid --var format: {var} (use key=value)")
+        key, value = var.split("=", 1)
+        variables[key] = value
+
+    body = fill_template(args.template, variables)
+
+    if args.dry_run:
+        print("--- PREVIEW ---")
+        print(body)
+        print("--- END PREVIEW ---")
+        return 0
+
+    if not args.repo or not args.issue:
+        parser.error("--repo and --issue are required (or use --dry-run)")
+
+    post_comment(args.repo, args.issue, body)
+
+    if args.close:
+        close_issue(args.repo, args.issue)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/jp_eslint.mjs
+++ b/jp_eslint.mjs
@@ -32,7 +32,9 @@ function isModuleFile(filePath) {
   if (extname(filePath) === ".cjs") return false;
   try {
     const src = readFileSync(filePath, "utf8");
-    return /\b(import\s+|export\s+(default\s+|const\s+|let\s+|var\s+|function\s+|class\s+|\{))/m.test(src);
+    // Match import/export only at the start of a line (ignoring leading whitespace)
+    // to avoid false positives from comments like "export/import"
+    return /^\s*(import\s+|export\s+(default\s+|const\s+|let\s+|var\s+|function\s+|class\s+|\{))/m.test(src);
   } catch {
     return false;
   }
@@ -87,27 +89,14 @@ const commonRules = {
   "prefer-template":       "warn",
 };
 
-// Browser globals
-const browserGlobals = {
-  window: "readonly", document: "readonly", console: "readonly",
-  fetch: "readonly", localStorage: "readonly", sessionStorage: "readonly",
-  setTimeout: "readonly", clearTimeout: "readonly",
-  setInterval: "readonly", clearInterval: "readonly",
-  URL: "readonly", Blob: "readonly", FileReader: "readonly",
-  Image: "readonly", requestAnimationFrame: "readonly",
-  alert: "readonly", confirm: "readonly", prompt: "readonly",
-  navigator: "readonly", location: "readonly",
-  performance: "readonly", HTMLElement: "readonly",
-  HTMLCanvasElement: "readonly", WebGLRenderingContext: "readonly",
-  Event: "readonly", MouseEvent: "readonly", KeyboardEvent: "readonly",
-};
+import globals from "globals";
+
+// Use the complete browser globals from the 'globals' package
+const browserGlobals = globals.browser;
 
 // Node/module globals
 const moduleGlobals = {
-  process: "readonly", console: "readonly",
-  setTimeout: "readonly", clearTimeout: "readonly",
-  setInterval: "readonly", clearInterval: "readonly",
-  URL: "readonly",
+  ...globals.node,
 };
 
 // Lint a single file with the correct config

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
   "dependencies": {
     "eslint": "^10.0.0",
     "eslint-plugin-html": "^8.0.0",
+    "globals": "^17.4.0",
+    "lebab": "^3.2.8",
     "postcss-html": "^1.8.1",
     "prettier": "^3.0.0",
     "stylelint": "^17.5.0",

--- a/snapshot-test.py
+++ b/snapshot-test.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""Snapshot testing for JS data structures.
+
+Captures output from a JS expression evaluated in Node, saves as JSON snapshots,
+and compares before/after refactoring.
+
+Usage:
+    # Capture a snapshot
+    python snapshot-test.py capture --name before-refactor --script test.mjs --output snapshots/
+
+    # Compare two snapshots
+    python snapshot-test.py compare snapshots/before-refactor.json snapshots/after-refactor.json
+
+    # Quick diff: capture and compare in one step
+    python snapshot-test.py diff --name refactor-test --script test.mjs --baseline snapshots/before-refactor.json
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+from datetime import datetime
+
+
+def capture_snapshot(script_path: str, name: str, output_dir: str) -> dict:
+    """Run a Node.js script and capture its JSON output as a snapshot."""
+    script = Path(script_path).resolve()
+    if not script.exists():
+        print(f"Error: {script_path} not found", file=sys.stderr)
+        sys.exit(1)
+
+    output = Path(output_dir)
+    output.mkdir(parents=True, exist_ok=True)
+
+    result = subprocess.run(
+        ["node", str(script)],
+        capture_output=True, text=True, timeout=60
+    )
+
+    if result.returncode != 0:
+        print(f"Script failed (exit {result.returncode}):", file=sys.stderr)
+        print(result.stderr, file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        data = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        print("Error: script output is not valid JSON", file=sys.stderr)
+        print(f"Output: {result.stdout[:500]}", file=sys.stderr)
+        sys.exit(1)
+
+    snapshot = {
+        "name": name,
+        "timestamp": datetime.now().isoformat(),
+        "script": str(script),
+        "data": data,
+    }
+
+    snapshot_path = output / f"{name}.json"
+    snapshot_path.write_text(json.dumps(snapshot, indent=2), encoding="utf-8")
+    print(f"Snapshot saved: {snapshot_path}")
+    return snapshot
+
+
+def compare_snapshots(path_a: str, path_b: str, verbose: bool = False) -> bool:
+    """Compare two snapshots and report differences."""
+    a = json.loads(Path(path_a).read_text(encoding="utf-8"))
+    b = json.loads(Path(path_b).read_text(encoding="utf-8"))
+
+    data_a = a["data"]
+    data_b = b["data"]
+
+    print(f"Comparing: {a['name']} vs {b['name']}")
+    print(f"  A: {a['timestamp']}")
+    print(f"  B: {b['timestamp']}")
+    print()
+
+    diffs = deep_diff(data_a, data_b, "")
+
+    if not diffs:
+        print("PASS: Snapshots are identical")
+        return True
+
+    print(f"FAIL: {len(diffs)} difference(s) found:")
+    print()
+    for diff in diffs[:50]:  # Cap output
+        print(f"  {diff['path']}")
+        print(f"    A: {json.dumps(diff['a'])[:100]}")
+        print(f"    B: {json.dumps(diff['b'])[:100]}")
+        print()
+
+    if len(diffs) > 50:
+        print(f"  ... and {len(diffs) - 50} more")
+
+    # Summary stats
+    if isinstance(data_a, dict) and isinstance(data_b, dict):
+        print("Summary:")
+        for key in sorted(set(list(data_a.keys()) + list(data_b.keys()))):
+            val_a = data_a.get(key)
+            val_b = data_b.get(key)
+            if isinstance(val_a, (int, float)) and isinstance(val_b, (int, float)):
+                delta = val_b - val_a
+                pct = (delta / val_a * 100) if val_a != 0 else float("inf")
+                status = "=" if delta == 0 else f"{'+' if delta > 0 else ''}{delta} ({pct:+.1f}%)"
+                print(f"  {key}: {val_a} → {val_b}  {status}")
+
+    return False
+
+
+def deep_diff(a, b, path: str) -> list[dict]:
+    """Recursively diff two JSON structures."""
+    diffs = []
+
+    if type(a) != type(b):
+        diffs.append({"path": path or "(root)", "a": a, "b": b})
+        return diffs
+
+    if isinstance(a, dict):
+        all_keys = set(list(a.keys()) + list(b.keys()))
+        for key in sorted(all_keys):
+            child_path = f"{path}.{key}" if path else key
+            if key not in a:
+                diffs.append({"path": child_path, "a": "(missing)", "b": b[key]})
+            elif key not in b:
+                diffs.append({"path": child_path, "a": a[key], "b": "(missing)"})
+            else:
+                diffs.extend(deep_diff(a[key], b[key], child_path))
+
+    elif isinstance(a, list):
+        if len(a) != len(b):
+            diffs.append({"path": f"{path}.length", "a": len(a), "b": len(b)})
+        for i in range(min(len(a), len(b))):
+            diffs.extend(deep_diff(a[i], b[i], f"{path}[{i}]"))
+
+    elif a != b:
+        # For floats, allow small tolerance
+        if isinstance(a, float) and isinstance(b, float):
+            if abs(a - b) > 1e-10:
+                diffs.append({"path": path, "a": a, "b": b})
+        else:
+            diffs.append({"path": path, "a": a, "b": b})
+
+    return diffs
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Snapshot testing for JS refactoring")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    cap = sub.add_parser("capture", help="Capture a snapshot")
+    cap.add_argument("--name", required=True, help="Snapshot name")
+    cap.add_argument("--script", required=True, help="Node.js script that outputs JSON")
+    cap.add_argument("--output", default="snapshots", help="Output directory")
+
+    cmp = sub.add_parser("compare", help="Compare two snapshots")
+    cmp.add_argument("snapshot_a", help="First snapshot JSON")
+    cmp.add_argument("snapshot_b", help="Second snapshot JSON")
+    cmp.add_argument("--verbose", "-v", action="store_true")
+
+    diff = sub.add_parser("diff", help="Capture and compare against baseline")
+    diff.add_argument("--name", required=True, help="Snapshot name")
+    diff.add_argument("--script", required=True, help="Node.js script")
+    diff.add_argument("--baseline", required=True, help="Baseline snapshot to compare against")
+    diff.add_argument("--output", default="snapshots", help="Output directory")
+
+    args = parser.parse_args()
+
+    if args.command == "capture":
+        capture_snapshot(args.script, args.name, args.output)
+        return 0
+
+    elif args.command == "compare":
+        ok = compare_snapshots(args.snapshot_a, args.snapshot_b, getattr(args, "verbose", False))
+        return 0 if ok else 1
+
+    elif args.command == "diff":
+        capture_snapshot(args.script, args.name, args.output)
+        snapshot_path = Path(args.output) / f"{args.name}.json"
+        ok = compare_snapshots(args.baseline, str(snapshot_path))
+        return 0 if ok else 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/templates/comment-templates/issue-closing.md
+++ b/templates/comment-templates/issue-closing.md
@@ -1,0 +1,9 @@
+## Resolved in #{pr_number}
+
+**What changed:** {summary}
+
+**Files touched:**
+{file_list}
+
+**How to verify:**
+{verification_steps}

--- a/templates/comment-templates/pr-review.md
+++ b/templates/comment-templates/pr-review.md
@@ -1,0 +1,12 @@
+## Review
+
+**Approach:** {approve|request-changes|comment}
+
+**What I checked:**
+{review_items}
+
+**Issues found:**
+{issues_or_none}
+
+**Suggestions:**
+{suggestions_or_none}

--- a/templates/comment-templates/spec.md
+++ b/templates/comment-templates/spec.md
@@ -1,0 +1,24 @@
+## Specification
+
+### Goal
+{what_this_should_accomplish}
+
+### Current behavior
+{how_it_works_today_or_n_a}
+
+### Desired behavior
+{how_it_should_work}
+
+### Acceptance criteria
+- [ ] {criterion_1}
+- [ ] {criterion_2}
+- [ ] {criterion_3}
+
+### Technical approach
+{implementation_notes_or_tbd}
+
+### Dependencies
+{related_issues_or_none}
+
+### Out of scope
+{what_this_does_not_cover}

--- a/templates/comment-templates/superseded.md
+++ b/templates/comment-templates/superseded.md
@@ -1,0 +1,7 @@
+## Superseded
+
+This issue is replaced by #{new_issue_number}.
+
+**Why:** {reason}
+
+Closing as superseded — the replacement issue covers the updated scope.

--- a/templates/comment-templates/triage.md
+++ b/templates/comment-templates/triage.md
@@ -1,0 +1,12 @@
+## Status update
+
+**Current state:** {open|in-progress|blocked|ready-for-review}
+
+**What's done:**
+{completed_items}
+
+**What's blocking:**
+{blockers_or_none}
+
+**Next steps:**
+{next_actions}


### PR DESCRIPTION
## Summary

Three new tools for safe refactoring:

- **diff-functions.py** — extract and side-by-side or unified diff two named functions from JS files. Shows similarity percentage.
- **count-callers.py** — find all definitions, calls, and references to a function across a codebase. Classifies each hit as DEF/CALL/REF/COMMENT.
- **snapshot-test.py** — capture JSON output from a Node script as a snapshot, compare before/after refactoring. Deep diff with float tolerance.

## Usage
```bash
python diff-functions.py file.js funcA funcB --stats
python count-callers.py processEscapePath /path/to/project --type js
python snapshot-test.py capture --name before --script test.mjs
python snapshot-test.py compare snapshots/before.json snapshots/after.json
```

Built to support the mandelbrotexplorer Hair/Cloud refactor (issues #1-3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)