### PR TITLE
Add TypeScript support to ESLint runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ or directories and returns structured JSON designed for AI agent consumption.
 git clone https://github.com/jparish1977/JP_TOOLS.git
 cd JP_TOOLS
 pip install ruff mypy pip-audit         # Python tools
-npm install                             # JS/CSS tools (eslint, stylelint, prettier)
+npm install                             # JS/TS/CSS tools (eslint, typescript-eslint, stylelint, prettier)
 composer install                        # PHP tools (phpstan, phpcs, rector)
 ```
 
@@ -64,7 +64,8 @@ and runs the appropriate tools for each:
 | Language | Extensions | Tools | Audit |
 |---|---|---|---|
 | Python | `.py` | ruff, mypy | pip-audit |
-| JavaScript | `.js`, `.ts`, `.jsx`, `.tsx` | eslint, prettier | npm audit |
+| JavaScript | `.js`, `.jsx` | eslint, prettier | npm audit |
+| TypeScript | `.ts`, `.tsx` | eslint (typescript-eslint), prettier | npm audit |
 | CSS | `.css`, `.scss`, `.less` | stylelint, prettier | — |
 | HTML | `.html` | eslint, stylelint, prettier | — |
 | PHP | `.php` | phpstan, phpcs, rector | composer audit |

--- a/jp_eslint.mjs
+++ b/jp_eslint.mjs
@@ -90,6 +90,7 @@ const commonRules = {
 };
 
 import globals from "globals";
+import tseslint from "typescript-eslint";
 
 // Use the complete browser globals from the 'globals' package
 const browserGlobals = globals.browser;
@@ -102,7 +103,8 @@ const moduleGlobals = {
 // Lint a single file with the correct config
 async function lintFile(filePath) {
   const isHtml = /\.html?$/.test(filePath);
-  const isModule = !isHtml && isModuleFile(filePath);
+  const isTs = /\.tsx?$/.test(filePath);
+  const isModule = !isHtml && (isTs || isModuleFile(filePath));
   const dir = dirname(filePath);
 
   const config = [];
@@ -117,6 +119,31 @@ async function lintFile(filePath) {
         globals: browserGlobals,
       },
       rules: commonRules,
+    });
+  } else if (isTs) {
+    // TypeScript files — use typescript-eslint parser
+    // Disable rules that conflict with TS type system
+    const tsRules = { ...commonRules };
+    delete tsRules["no-undef"];          // TS handles this
+    delete tsRules["no-unused-vars"];    // use @typescript-eslint version instead
+    delete tsRules["no-redeclare"];      // TS handles this
+    delete tsRules["no-shadow"];         // TS handles this
+
+    config.push({
+      files: ["**"],
+      languageOptions: {
+        ecmaVersion: 2022,
+        sourceType: "module",
+        parser: tseslint.parser,
+        globals: { ...browserGlobals, ...moduleGlobals },
+      },
+      plugins: {
+        "@typescript-eslint": tseslint.plugin,
+      },
+      rules: {
+        ...tsRules,
+        "@typescript-eslint/no-unused-vars": ["error", { argsIgnorePattern: "^_", varsIgnorePattern: "^_", caughtErrors: "none" }],
+      },
     });
   } else {
     const scriptOverrides = isModule ? {} : {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "description": "Code quality toolbox for agentic AI development",
   "dependencies": {
+    "@typescript-eslint/parser": "^8.58.0",
     "eslint": "^10.0.0",
     "eslint-plugin-html": "^8.0.0",
     "globals": "^17.4.0",
@@ -12,6 +13,8 @@
     "postcss-html": "^1.8.1",
     "prettier": "^3.0.0",
     "stylelint": "^17.5.0",
-    "stylelint-config-standard": "^40.0.0"
+    "stylelint-config-standard": "^40.0.0",
+    "typescript": "^6.0.2",
+    "typescript-eslint": "^8.58.0"
   }
 }


### PR DESCRIPTION
## Summary
- `jp_eslint.mjs` now detects `.ts`/`.tsx` files and uses `typescript-eslint` parser
- Disables rules that conflict with the TS type system (`no-undef`, `no-redeclare`, `no-shadow`)
- Uses `@typescript-eslint/no-unused-vars` for TS files
- Added `typescript-eslint`, `@typescript-eslint/parser`, and `typescript` as npm dependencies
- Updated README to document TypeScript as a separate language row

## Test plan
- [x] Tested against `telnet-dungeon` web frontend (3 TS files) — 0 parse errors, all real lint issues caught
- [x] Existing JS/HTML linting unchanged
- [x] Full `check.py` run: 0 errors, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)