### PR TITLE
Bump CI actions for Node.js 24 compatibility

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -11,8 +11,8 @@ jobs:
     name: Python (ruff + mypy)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
       - run: pip install ruff mypy
@@ -27,11 +27,11 @@ jobs:
     name: JS (eslint)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '22'
       - run: npm install


### PR DESCRIPTION
## Summary

- Node.js 20 actions are deprecated, forced to Node.js 24 starting June 2, 2026
- Bumps `actions/checkout` v4→v6, `actions/setup-python` v5→v6, `actions/setup-node` v4→v6

## Test plan

- [x] CI should pass on this PR with no deprecation warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)