### PR TITLE
Add recovery toolkit: CHD, file recovery, disk imaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,21 +2,30 @@
 
 [![Code Quality](https://github.com/jparish1977/JP_TOOLS/actions/workflows/check.yml/badge.svg)](https://github.com/jparish1977/JP_TOOLS/actions/workflows/check.yml)
 
-Code quality toolbox for use with agentic AI in professional software development.
-Runs linters, type checkers, formatters, and security auditors against arbitrary files
-or directories and returns structured JSON designed for AI agent consumption.
+Developer toolbox for code quality, data recovery, file analysis, and archive management.
+Built with pluggable interfaces — every tool is coded to contracts with swappable adapters.
 
 ## Quick Start
 
 ```bash
 git clone https://github.com/jparish1977/JP_TOOLS.git
 cd JP_TOOLS
-pip install ruff mypy pip-audit         # Python tools
-npm install                             # JS/TS/CSS tools (eslint, typescript-eslint, stylelint, prettier)
-composer install                        # PHP tools (phpstan, phpcs, rector)
+
+# Code quality tools
+pip install ruff mypy pip-audit         # Python linting/typing
+npm install                             # JS/TS/CSS (eslint, typescript-eslint, stylelint, prettier)
+composer install                        # PHP (phpstan, phpcs, rector, phpunit)
+
+# Recovery & analysis tools (Linux/WSL)
+bash install-recovery.sh
+
+# Recovery & analysis tools (Windows native)
+powershell install-recovery.ps1
 ```
 
-## Scripts
+## Tools
+
+### Code Quality
 
 | Script | Purpose |
 |---|---|
@@ -24,6 +33,37 @@ composer install                        # PHP tools (phpstan, phpcs, rector)
 | `fix.py` | Auto-fix what's fixable, report what isn't |
 | `install-hooks.py` | Install pre-commit hook into any git repo |
 | `init-ci.py` | Copy GitHub Actions CI template into a repo |
+
+### File Analysis (PHP — hex architecture)
+
+| Script | Purpose |
+|---|---|
+| `find-dupes.php` | Find duplicate files or compare directories |
+| | Pluggable hashers, caches (memory, filesystem, SQLite), output formats |
+| | Worker pool for parallel hashing, persistent hash DB for instant re-scans |
+
+### Data Recovery (Python)
+
+| Script | Purpose |
+|---|---|
+| `recover.py` | File recovery via photorec with profile-based filtering |
+| `undelete.py` | Recover deleted files from NTFS/ext filesystems |
+| `image-disk.py` | Forensic disk imaging via ddrescue |
+| `scan-image.py` | Scan raw images for ROM signatures and embedded files |
+
+### Archive Management (Python)
+
+| Script | Purpose |
+|---|---|
+| `chd.py` | CHD archive management — create, verify, extract, import, delta, batch |
+| `chd-hunkmap.py` | CHD hunk map analysis — block-level dedup intelligence |
+
+### Deployment
+
+| Script | Purpose |
+|---|---|
+| `deploy-s3.py` | Deploy static sites to S3 |
+| `deploy-all.py` | S3 + GitHub Pages deploy |
 
 ## Usage
 
@@ -134,3 +174,149 @@ python init-ci.py /path/to/repo
 ```
 
 Creates `.github/workflows/check.yml` — runs on push to main and on PRs.
+
+## FileScanner Library
+
+PHP library with hexagonal architecture — interfaces for everything, swap adapters without touching business logic.
+
+```
+lib/FileScanner/
+├── Contract/           Interfaces (ports)
+│   ├── HasherInterface.php
+│   ├── FilesystemInterface.php
+│   ├── CacheInterface.php
+│   ├── OutputInterface.php
+│   ├── ScannerInterface.php
+│   ├── SchedulerInterface.php
+│   └── DuplicateFinderInterface.php
+├── Hasher/             Hash adapters
+│   ├── NativeHasher.php        PHP hash_file() — cross-platform
+│   └── ShellHasher.php         md5sum/sha256sum — Linux, parallel-friendly
+├── Cache/              Storage adapters
+│   ├── MemoryCache.php          In-memory, single-run
+│   ├── FilesystemCache.php      File-per-hash on disk
+│   └── SqliteCache.php          Persistent DB, staleness checks, dupe queries
+├── Filesystem/
+│   └── LocalFilesystem.php      Native filesystem adapter
+├── Output/
+│   ├── ConsoleOutput.php        Human-readable terminal output
+│   └── JsonOutput.php           Machine-readable JSON
+├── Scheduler/
+│   ├── SequentialScheduler.php  One-at-a-time (default)
+│   ├── WorkerPoolScheduler.php  Parallel via proc_open worker pool
+│   └── hash-worker.php          Worker process for parallel hashing
+├── Scanner.php          Directory walker + hasher
+├── DuplicateFinder.php  Find dupes within or across directories
+├── FileEntry.php        Value object
+├── DuplicateGroup.php   Value object
+├── ComparisonResult.php Value object
+└── tests/
+    ├── HasherTest.php
+    ├── CacheTest.php
+    ├── ValueObjectTest.php
+    ├── ScannerTest.php
+    ├── DuplicateFinderTest.php
+    └── phpunit.xml
+```
+
+### find-dupes.php Usage
+
+```bash
+# Find duplicates within a directory
+php find-dupes.php ~/Pictures
+
+# Compare two directories
+php find-dupes.php ~/backup1 ~/backup2
+
+# JSON output
+php find-dupes.php ~/data --json
+
+# Persistent SQLite cache (hash once, instant re-scans)
+php find-dupes.php ~/data --db ~/.hash-cache.db
+
+# SHA-256 instead of MD5
+php find-dupes.php ~/data --algo sha256
+
+# Parallel hashing with 4 worker processes
+php find-dupes.php ~/data --workers 4
+
+# Ignore specific directories
+php find-dupes.php ~/data --ignore vendor,node_modules
+```
+
+## Recovery Tools
+
+### Profiles (recover.py)
+
+| Profile | File Types |
+|---|---|
+| `code` | JS, HTML, PHP, Python, JSON, XML, CSS, SQL, shell, etc. |
+| `art` | PNG, JPG, TIFF, PSD, BMP, GIF, SVG, WebP, etc. |
+| `writing` | TXT, PDF, DOC, ODT, RTF, MD, EPUB, etc. |
+| `roms` | NES, SNES, GB, GBA, N64, ISO, BIN, CHD, ZIP, 7z, etc. |
+| `all` | All of the above |
+| `full` | Everything photorec can find |
+
+```bash
+# Recover code files from a drive
+python recover.py /dev/sdb1 ./recovered --profile code
+
+# Recover everything
+python recover.py F: ./recovered --profile all
+```
+
+### CHD Archive Management
+
+```bash
+# Create CHD from disc image
+python chd.py create game.iso game.chd
+
+# Import any format (auto-converts CSO, PBP, NRG, MDF, ECM)
+python chd.py import game.cso game.chd
+
+# Batch convert a whole directory
+python chd.py batch-create ~/roms/psx --format iso
+
+# Verify integrity
+python chd.py verify game.chd
+python chd.py batch-verify ~/roms/chd
+
+# Delta (incremental) CHD
+python chd.py delta base.chd updated.img updated.chd
+
+# Analyze block-level deduplication
+python chd-hunkmap.py archive.chd --self-refs --trace archive.tar
+```
+
+### ROM Signature Scanner
+
+```bash
+# Scan a disk image for ROM magic bytes
+python scan-image.py disk.img --signatures roms
+
+# Scan with binwalk + ROM signatures
+python scan-image.py disk.img --signatures all --output ./results
+```
+
+Detects: NES, SNES, Game Boy, GBA, N64, Genesis, Master System, Game Gear,
+Atari 7800, Atari Lynx, Neo Geo, FDS, Sega 32X, Sega CD, CHD, CSO, CUE,
+PBP, WBFS, NKit, GameCube, 3DS, NDS, WordPerfect, ISO 9660.
+
+## Testing
+
+```bash
+# PHP unit tests (46 tests, 107 assertions)
+php vendor/bin/phpunit --configuration lib/FileScanner/tests/phpunit.xml
+
+# PHP with coverage (requires PCOV)
+php vendor/bin/phpunit --configuration lib/FileScanner/tests/phpunit.xml --coverage-text
+
+# PHP static analysis (level 8)
+php vendor/bin/phpstan analyse lib/FileScanner/ --level=8
+
+# PHP code style (PSR-12)
+php vendor/bin/phpcs lib/FileScanner/ --standard=PSR12
+
+# Python linting
+ruff check recover.py image-disk.py undelete.py scan-image.py chd.py chd-hunkmap.py
+```

--- a/chd-hunkmap.py
+++ b/chd-hunkmap.py
@@ -1,0 +1,414 @@
+#!/usr/bin/env python
+"""
+JP_TOOLS/chd-hunkmap.py
+Read and analyze a CHD v5 hunk map — find self-referencing (duplicate) hunks
+and trace them back to files in a tar archive.
+
+Usage:
+    python chd-hunkmap.py <file.chd>                     Show hunk map summary
+    python chd-hunkmap.py <file.chd> --self-refs         List all self-referencing hunks
+    python chd-hunkmap.py <file.chd> --trace <tar>       Trace self-refs back to tar file entries
+    python chd-hunkmap.py <file.chd> --json              Output as JSON
+"""
+
+import struct
+import sys
+import argparse
+import json
+import tarfile
+from pathlib import Path
+from collections import defaultdict
+
+
+COMPRESSION_NAMES = {
+    0: "codec_0",
+    1: "codec_1",
+    2: "codec_2",
+    3: "codec_3",
+    4: "uncompressed",
+    5: "self_ref",
+    6: "parent_ref",
+}
+
+
+def read_chd_header(f):
+    """Read CHD v5 header (124 bytes)."""
+    magic = f.read(8)
+    if magic != b'MComprHD':
+        raise ValueError(f"Not a CHD file (magic: {magic})")
+
+    f.read(4)  # header_size — consumed to advance file position
+    version = struct.unpack('>I', f.read(4))[0]
+
+    if version != 5:
+        raise ValueError(f"Only CHD v5 supported, got v{version}")
+
+    codecs = []
+    for _ in range(4):
+        codec_bytes = f.read(4)
+        codec = codec_bytes.decode('ascii', errors='replace').strip('\x00')
+        codecs.append(codec if codec else None)
+
+    logical_size = struct.unpack('>Q', f.read(8))[0]
+    map_offset = struct.unpack('>Q', f.read(8))[0]
+    meta_offset = struct.unpack('>Q', f.read(8))[0]
+    hunk_size = struct.unpack('>I', f.read(4))[0]
+    unit_size = struct.unpack('>I', f.read(4))[0]
+    raw_sha1 = f.read(20).hex()
+    sha1 = f.read(20).hex()
+    parent_sha1 = f.read(20).hex()
+
+    hunk_count = (logical_size + hunk_size - 1) // hunk_size
+
+    return {
+        'version': version,
+        'codecs': [c for c in codecs if c],
+        'logical_size': logical_size,
+        'map_offset': map_offset,
+        'meta_offset': meta_offset,
+        'hunk_size': hunk_size,
+        'unit_size': unit_size,
+        'hunk_count': hunk_count,
+        'raw_sha1': raw_sha1,
+        'sha1': sha1,
+        'parent_sha1': parent_sha1,
+    }
+
+
+class BitReader:
+    """Read individual bits from a byte buffer."""
+
+    def __init__(self, data):
+        self.data = data
+        self.byte_pos = 0
+        self.bit_pos = 0
+
+    def read_bits(self, count):
+        """Read `count` bits and return as integer."""
+        result = 0
+        for _ in range(count):
+            if self.byte_pos >= len(self.data):
+                return result
+            byte = self.data[self.byte_pos]
+            bit = (byte >> (7 - self.bit_pos)) & 1
+            result = (result << 1) | bit
+            self.bit_pos += 1
+            if self.bit_pos >= 8:
+                self.bit_pos = 0
+                self.byte_pos += 1
+        return result
+
+    def bits_remaining(self):
+        return (len(self.data) - self.byte_pos) * 8 - self.bit_pos
+
+
+def read_compressed_map(f, header):
+    """Read the compressed hunk map using variable-width bitstream."""
+    f.seek(header['map_offset'])
+
+    # Map header (16 bytes)
+    map_size = struct.unpack('>I', f.read(4))[0]
+    first_offset_bytes = f.read(6)
+    first_offset = int.from_bytes(first_offset_bytes, 'big')
+    f.read(2)  # map_crc — consumed to advance file position
+    size_bits = struct.unpack('B', f.read(1))[0]
+    self_bits = struct.unpack('B', f.read(1))[0]
+    parent_bits = struct.unpack('B', f.read(1))[0]
+    f.read(1)  # reserved — consumed to advance file position
+
+    # Read and decompress the map data
+    compressed_map_data = f.read(map_size)
+
+    import zlib
+    try:
+        decompressed = zlib.decompress(compressed_map_data, -15)
+    except zlib.error:
+        try:
+            decompressed = zlib.decompress(compressed_map_data)
+        except zlib.error:
+            decompressed = compressed_map_data
+
+    # The decompressed data is a bitstream where each entry has:
+    #   compression_type: 3 bits (0-3=codec, 4=uncompressed, 5=self, 6=parent)
+    #   length:           size_bits (compressed size)
+    #   offset/ref:       depends on type
+    #     compressed:      offset delta (cumulative from first_offset)
+    #     uncompressed:    offset delta
+    #     self_ref:        self_bits (target hunk number)
+    #     parent_ref:      parent_bits (target hunk in parent)
+    #   crc:              16 bits
+
+    reader = BitReader(decompressed)
+    entries = []
+    current_offset = first_offset
+
+    for i in range(header['hunk_count']):
+        if reader.bits_remaining() < 3:
+            break
+
+        comp_type = reader.read_bits(3)
+
+        if comp_type == 5:  # self_ref
+            target = reader.read_bits(self_bits)
+            crc = reader.read_bits(16)
+            entry = {
+                'hunk': i,
+                'type': 5,
+                'type_name': 'self_ref',
+                'block_size': 0,
+                'offset': 0,
+                'target_hunk': target,
+                'crc': crc,
+            }
+        elif comp_type == 6:  # parent_ref
+            target = reader.read_bits(parent_bits)
+            crc = reader.read_bits(16)
+            entry = {
+                'hunk': i,
+                'type': 6,
+                'type_name': 'parent_ref',
+                'block_size': 0,
+                'offset': 0,
+                'target_hunk': target,
+                'crc': crc,
+            }
+        elif comp_type == 4:  # uncompressed
+            length = reader.read_bits(size_bits)
+            crc = reader.read_bits(16)
+            entry = {
+                'hunk': i,
+                'type': 4,
+                'type_name': 'uncompressed',
+                'block_size': header['hunk_size'],
+                'offset': current_offset,
+                'crc': crc,
+            }
+            current_offset += header['hunk_size']
+        else:  # compressed (codec 0-3)
+            length = reader.read_bits(size_bits)
+            crc = reader.read_bits(16)
+            entry = {
+                'hunk': i,
+                'type': comp_type,
+                'type_name': COMPRESSION_NAMES.get(comp_type, f'codec_{comp_type}'),
+                'block_size': length,
+                'offset': current_offset,
+                'crc': crc,
+            }
+            current_offset += length
+
+        entries.append(entry)
+
+    return entries, {
+        'map_size': map_size,
+        'first_offset': first_offset,
+        'size_bits': size_bits,
+        'self_bits': self_bits,
+        'parent_bits': parent_bits,
+    }
+
+
+def read_uncompressed_map(f, header):
+    """Read uncompressed hunk map (simple offset table)."""
+    f.seek(header['map_offset'])
+    entries = []
+    for i in range(header['hunk_count']):
+        offset = struct.unpack('>I', f.read(4))[0]
+        entries.append({
+            'hunk': i,
+            'type': 4,  # uncompressed
+            'type_name': 'uncompressed',
+            'block_size': header['hunk_size'],
+            'offset': offset,
+            'crc': 0,
+        })
+    return entries, {}
+
+
+def build_tar_map(tar_path, hunk_size):
+    """Build a map of byte offset ranges to tar file entries."""
+    file_map = []
+    with tarfile.open(tar_path, 'r') as tar:
+        for member in tar.getmembers():
+            if member.isfile():
+                # tar data starts at the member's offset + header (512 bytes typically)
+                data_offset = member.offset_data
+                file_map.append({
+                    'name': member.name,
+                    'offset': data_offset,
+                    'size': member.size,
+                    'start_hunk': data_offset // hunk_size,
+                    'end_hunk': (data_offset + member.size - 1) // hunk_size if member.size > 0 else data_offset // hunk_size,
+                })
+    return file_map
+
+
+def hunk_to_file(hunk_num, tar_map, hunk_size):
+    """Find which file(s) a hunk belongs to."""
+    byte_offset = hunk_num * hunk_size
+    for entry in tar_map:
+        if entry['offset'] <= byte_offset < entry['offset'] + entry['size']:
+            return entry['name']
+    return None
+
+
+def analyze_self_refs(entries, tar_map=None, hunk_size=4096):
+    """Analyze self-referencing hunks and optionally trace to files."""
+    self_refs = [e for e in entries if e['type'] == 5]
+
+    # Group by target — which hunks are being referenced by multiple self-refs?
+    target_groups = defaultdict(list)
+    for ref in self_refs:
+        target_groups[ref['target_hunk']].append(ref['hunk'])
+
+    results = []
+    for target, referrers in sorted(target_groups.items()):
+        group = {
+            'target_hunk': target,
+            'target_byte_offset': target * hunk_size,
+            'referencing_hunks': referrers,
+            'count': len(referrers),
+        }
+
+        if tar_map:
+            target_file = hunk_to_file(target, tar_map, hunk_size)
+            ref_files = set()
+            for r in referrers:
+                rf = hunk_to_file(r, tar_map, hunk_size)
+                if rf:
+                    ref_files.add(rf)
+
+            group['target_file'] = target_file
+            group['referencing_files'] = sorted(ref_files)
+            group['cross_file'] = target_file not in ref_files if target_file else False
+
+        results.append(group)
+
+    return results
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Analyze CHD v5 hunk map — find duplicate blocks and trace to files.",
+    )
+    parser.add_argument("chd", help="CHD file to analyze")
+    parser.add_argument("--self-refs", action="store_true",
+                        help="List all self-referencing (duplicate) hunks")
+    parser.add_argument("--trace", metavar="TAR",
+                        help="Trace self-refs back to files in this tar archive")
+    parser.add_argument("--json", action="store_true",
+                        help="Output as JSON")
+    parser.add_argument("--top", type=int, default=20,
+                        help="Show top N duplicate groups (default: 20)")
+    args = parser.parse_args()
+
+    chd_path = Path(args.chd)
+    if not chd_path.exists():
+        print(f"Error: {chd_path} not found")
+        sys.exit(1)
+
+    with open(chd_path, 'rb') as f:
+        header = read_chd_header(f)
+
+        print(f"CHD v{header['version']}: {chd_path.name}")
+        print(f"  Logical size: {header['logical_size']:,} bytes ({round(header['logical_size'] / (1024**2), 1)} MB)")
+        print(f"  Hunk size:    {header['hunk_size']:,} bytes")
+        print(f"  Total hunks:  {header['hunk_count']:,}")
+        print(f"  Codecs:       {', '.join(header['codecs'])}")
+        print()
+
+        # Read hunk map
+        is_compressed = header['codecs'][0] != '' and header['codecs'][0] is not None
+        if is_compressed:
+            entries, map_info = read_compressed_map(f, header)
+        else:
+            entries, map_info = read_uncompressed_map(f, header)
+
+    if not entries:
+        print("Error: Could not parse hunk map")
+        sys.exit(1)
+
+    # Summary by type
+    type_counts = defaultdict(int)
+    for e in entries:
+        type_counts[e['type_name']] += 1
+
+    print(f"Hunk map ({len(entries)} entries):")
+    for name, count in sorted(type_counts.items(), key=lambda x: -x[1]):
+        pct = round(count / len(entries) * 100, 1)
+        print(f"  {name:20s} {count:>8,}  ({pct}%)")
+
+    self_ref_count = type_counts.get('self_ref', 0)
+    print(f"\n  Self-referencing hunks: {self_ref_count}")
+    print(f"  Deduplicated bytes:    {self_ref_count * header['hunk_size']:,} ({round(self_ref_count * header['hunk_size'] / (1024**2), 1)} MB)")
+
+    # Build tar map if tracing
+    tar_map = None
+    if args.trace:
+        tar_path = Path(args.trace)
+        if not tar_path.exists():
+            print(f"Error: Tar file not found: {tar_path}")
+            sys.exit(1)
+        print(f"\nBuilding tar file map from {tar_path.name}...")
+        tar_map = build_tar_map(str(tar_path), header['hunk_size'])
+        print(f"  {len(tar_map)} files in tar")
+
+    # Analyze self-refs
+    if args.self_refs or args.trace:
+        print("\nAnalyzing self-references...")
+        groups = analyze_self_refs(entries, tar_map, header['hunk_size'])
+
+        if args.json:
+            output = {
+                'chd': str(chd_path),
+                'header': header,
+                'hunk_summary': dict(type_counts),
+                'self_ref_groups': groups[:args.top] if not args.json else groups,
+                'total_self_refs': self_ref_count,
+                'dedup_bytes': self_ref_count * header['hunk_size'],
+            }
+            print(json.dumps(output, indent=2, default=str))
+        else:
+            # Sort by count descending
+            groups.sort(key=lambda g: g['count'], reverse=True)
+
+            print(f"\nTop {min(args.top, len(groups))} duplicate block groups:")
+            for g in groups[:args.top]:
+                print(f"\n  Target hunk {g['target_hunk']} (offset 0x{g['target_byte_offset']:X})")
+                print(f"    Referenced by {g['count']} other hunk(s): {g['referencing_hunks'][:10]}{'...' if g['count'] > 10 else ''}")
+
+                if tar_map:
+                    print(f"    Target file: {g.get('target_file', 'unknown')}")
+                    ref_files = g.get('referencing_files', [])
+                    if ref_files:
+                        print("    Referencing files:")
+                        for rf in ref_files[:5]:
+                            print(f"      - {rf}")
+                        if len(ref_files) > 5:
+                            print(f"      ... and {len(ref_files) - 5} more")
+                    if g.get('cross_file'):
+                        print("    ** CROSS-FILE DUPLICATE **")
+
+            # Cross-file summary
+            if tar_map:
+                cross_file = [g for g in groups if g.get('cross_file')]
+                same_file = [g for g in groups if not g.get('cross_file')]
+                print("\n  Summary:")
+                print(f"    Same-file duplicates:  {len(same_file)} groups")
+                print(f"    Cross-file duplicates: {len(cross_file)} groups")
+                if cross_file:
+                    # Find which file pairs share the most blocks
+                    pair_counts = defaultdict(int)
+                    for g in cross_file:
+                        target = g.get('target_file', 'unknown')
+                        for rf in g.get('referencing_files', []):
+                            pair = tuple(sorted([target, rf]))
+                            pair_counts[pair] += 1
+
+                    print("\n  Top file pairs sharing blocks:")
+                    for pair, count in sorted(pair_counts.items(), key=lambda x: -x[1])[:10]:
+                        print(f"    {count} shared blocks: {pair[0]} <-> {pair[1]}")
+
+
+if __name__ == "__main__":
+    main()

--- a/chd.py
+++ b/chd.py
@@ -1,0 +1,962 @@
+#!/usr/bin/env python
+"""
+JP_TOOLS/chd.py
+Wrapper for chdman — compressed hunk of data management.
+
+Create, verify, extract, diff, and manage CHD archives for disc images,
+raw disk dumps, and general compressed storage.
+
+Usage:
+    python chd.py create <input> <output.chd> [options]
+    python chd.py verify <file.chd>
+    python chd.py extract <file.chd> <output>
+    python chd.py info <file.chd>
+    python chd.py delta <parent.chd> <child-input> <child.chd>
+    python chd.py merge <child.chd> <output.chd>
+    python chd.py batch-create <directory> [--format <ext>] [--delete-originals]
+    python chd.py batch-verify <directory>
+    python chd.py compare <file1.chd> <file2.chd>
+    python chd.py convert <input.chd> <output.chd> [--compression <type>]
+
+Input formats:  .img, .bin, .iso, .raw, .cue, .gdi, .toc
+Output:         .chd (compressed hunk of data)
+
+Examples:
+    python chd.py create game.iso game.chd
+    python chd.py create disk.img disk.chd --compression lzma
+    python chd.py create game.cue game.chd                      # CD with cue sheet
+    python chd.py create game.gdi game.chd                      # Dreamcast GDI
+    python chd.py delta base.chd updated.img updated.chd        # Delta/child CHD
+    python chd.py batch-create ~/roms/psx --format iso           # Convert all ISOs
+    python chd.py batch-verify ~/roms/chd                        # Verify all CHDs
+    python chd.py info game.chd                                  # Show metadata
+"""
+
+import sys
+import shutil
+import subprocess
+import argparse
+import json
+from pathlib import Path
+from datetime import datetime
+
+
+COMPRESSION_PRESETS = {
+    "default": [],  # let chdman decide
+    "lzma": ["--compression", "lzma"],
+    "zlib": ["--compression", "zlib"],
+    "flac": ["--compression", "flac"],  # best for audio tracks
+    "none": ["--compression", "none"],
+    "best": ["--compression", "lzma"],
+    "fast": ["--compression", "zlib"],
+}
+
+# File extensions that can be converted to CHD
+CONVERTIBLE_EXTENSIONS = {
+    ".iso", ".img", ".bin", ".raw",  # raw disc/disk images
+    ".cue",  # CD cue sheets (will include referenced .bin files)
+    ".gdi",  # Dreamcast disc images
+    ".toc",  # CD TOC files
+}
+
+
+def find_chdman():
+    """Find chdman binary — check native Windows, PATH, then WSL."""
+    # Native Windows locations
+    if sys.platform == 'win32':
+        native_paths = [
+            Path.home() / "tools" / "mame" / "chdman.exe",
+            Path.home() / "tools" / "chdman.exe",
+        ]
+        for p in native_paths:
+            if p.exists():
+                return str(p)
+
+    # PATH
+    path = shutil.which("chdman")
+    if path:
+        return path
+
+    # Try WSL
+    if sys.platform == 'win32':
+        try:
+            result = subprocess.run(
+                ["wsl", "which", "chdman"],
+                capture_output=True, text=True
+            )
+            if result.returncode == 0 and result.stdout.strip():
+                return "wsl:" + result.stdout.strip()
+        except FileNotFoundError:
+            pass
+
+    return None
+
+
+def run_chdman(args, chdman_path=None):
+    """Run chdman with the given arguments."""
+    if chdman_path is None:
+        chdman_path = find_chdman()
+
+    if chdman_path is None:
+        print("Error: chdman not found.")
+        print("Install with:")
+        print("  Ubuntu/Debian: sudo apt install mame-tools")
+        print("  macOS: brew install rom-tools")
+        print("  Windows: download MAME and add to PATH")
+        sys.exit(2)
+
+    if chdman_path.startswith("wsl:"):
+        cmd = ["wsl", chdman_path[4:]] + args
+    else:
+        cmd = [chdman_path] + args
+
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    return result
+
+
+def cmd_create(args):
+    """Create a CHD from an input file."""
+    input_path = Path(args.input).resolve()
+    output_path = Path(args.output).resolve()
+
+    if not input_path.exists():
+        print(f"Error: Input file not found: {input_path}")
+        sys.exit(1)
+
+    ext = input_path.suffix.lower()
+
+    # Determine chdman subcommand based on input type
+    if ext in (".cue", ".gdi", ".toc"):
+        subcmd = "createcd"
+        input_flag = "--input"
+    elif ext in (".img", ".bin", ".iso", ".raw"):
+        subcmd = "createraw"
+        input_flag = "--input"
+        # Raw needs hunk size — default 4096 for hard drives, CD sector for discs
+        if not args.hunk_size:
+            args.hunk_size = "2048"  # CD sector size default
+    else:
+        print(f"Warning: Unknown extension {ext}, treating as raw image")
+        subcmd = "createraw"
+        input_flag = "--input"
+        if not args.hunk_size:
+            args.hunk_size = "4096"
+
+    cmd = [subcmd, input_flag, str(input_path), "--output", str(output_path)]
+
+    if args.compression and args.compression in COMPRESSION_PRESETS:
+        cmd.extend(COMPRESSION_PRESETS[args.compression])
+    elif args.compression:
+        cmd.extend(["--compression", args.compression])
+
+    if args.hunk_size:
+        cmd.extend(["--hunksize", str(args.hunk_size)])
+
+    if args.force:
+        cmd.append("--force")
+
+    input_size = input_path.stat().st_size
+    print(f"Creating CHD from: {input_path} ({round(input_size / (1024**3), 2)} GB)")
+    print(f"Output: {output_path}")
+    print(f"Mode: {subcmd}")
+
+    if args.dry_run:
+        print(f"[DRY RUN] Would run: chdman {' '.join(cmd)}")
+        return
+
+    result = run_chdman(cmd)
+    print(result.stdout)
+    if result.stderr:
+        print(result.stderr)
+
+    if result.returncode == 0 and output_path.exists():
+        output_size = output_path.stat().st_size
+        ratio = round(output_size / input_size * 100, 1) if input_size > 0 else 0
+        saved = input_size - output_size
+        print(f"\nCreated: {output_path}")
+        print(f"  Input:  {round(input_size / (1024**2), 1)} MB")
+        print(f"  Output: {round(output_size / (1024**2), 1)} MB")
+        print(f"  Ratio:  {ratio}% ({round(saved / (1024**2), 1)} MB saved)")
+
+    sys.exit(result.returncode)
+
+
+def cmd_verify(args):
+    """Verify a CHD file's integrity."""
+    chd_path = Path(args.file).resolve()
+
+    if not chd_path.exists():
+        print(f"Error: File not found: {chd_path}")
+        sys.exit(1)
+
+    print(f"Verifying: {chd_path}")
+    result = run_chdman(["verify", "--input", str(chd_path)])
+    print(result.stdout)
+    if result.stderr:
+        print(result.stderr)
+
+    if result.returncode == 0:
+        print("PASSED — CHD is valid")
+    else:
+        print("FAILED — CHD is corrupt or invalid")
+
+    sys.exit(result.returncode)
+
+
+def cmd_extract(args):
+    """Extract a CHD back to raw format."""
+    chd_path = Path(args.file).resolve()
+    output_path = Path(args.output).resolve()
+
+    if not chd_path.exists():
+        print(f"Error: File not found: {chd_path}")
+        sys.exit(1)
+
+    # Detect if CD or raw
+    info = get_chd_info(chd_path)
+    if info and "CD-ROM" in info.get("type", ""):
+        subcmd = "extractcd"
+    else:
+        subcmd = "extractraw"
+
+    cmd = [subcmd, "--input", str(chd_path), "--output", str(output_path)]
+
+    if args.force:
+        cmd.append("--force")
+
+    print(f"Extracting: {chd_path}")
+    print(f"Output: {output_path}")
+
+    if args.dry_run:
+        print(f"[DRY RUN] Would run: chdman {' '.join(cmd)}")
+        return
+
+    result = run_chdman(cmd)
+    print(result.stdout)
+    if result.stderr:
+        print(result.stderr)
+
+    sys.exit(result.returncode)
+
+
+def cmd_info(args):
+    """Show CHD metadata."""
+    chd_path = Path(args.file).resolve()
+
+    if not chd_path.exists():
+        print(f"Error: File not found: {chd_path}")
+        sys.exit(1)
+
+    result = run_chdman(["info", "--verbose", "--input", str(chd_path)])
+    print(result.stdout)
+    if result.stderr:
+        print(result.stderr)
+
+    if args.json:
+        info = get_chd_info(chd_path)
+        if info:
+            print(json.dumps(info, indent=2))
+
+    sys.exit(result.returncode)
+
+
+def cmd_delta(args):
+    """Create a delta (child) CHD from a parent."""
+    parent_path = Path(args.parent).resolve()
+    input_path = Path(args.input).resolve()
+    output_path = Path(args.output).resolve()
+
+    if not parent_path.exists():
+        print(f"Error: Parent CHD not found: {parent_path}")
+        sys.exit(1)
+    if not input_path.exists():
+        print(f"Error: Input file not found: {input_path}")
+        sys.exit(1)
+
+    ext = input_path.suffix.lower()
+    if ext in (".cue", ".gdi", ".toc"):
+        subcmd = "createcd"
+    else:
+        subcmd = "createraw"
+
+    cmd = [subcmd,
+           "--input", str(input_path),
+           "--output", str(output_path),
+           "--inputparent", str(parent_path)]
+
+    print("Creating delta CHD")
+    print(f"  Parent: {parent_path}")
+    print(f"  Input:  {input_path}")
+    print(f"  Output: {output_path}")
+
+    if args.dry_run:
+        print(f"[DRY RUN] Would run: chdman {' '.join(cmd)}")
+        return
+
+    result = run_chdman(cmd)
+    print(result.stdout)
+    if result.stderr:
+        print(result.stderr)
+
+    if result.returncode == 0 and output_path.exists():
+        parent_size = parent_path.stat().st_size
+        input_size = input_path.stat().st_size
+        output_size = output_path.stat().st_size
+        print(f"\n  Parent size: {round(parent_size / (1024**2), 1)} MB")
+        print(f"  Input size:  {round(input_size / (1024**2), 1)} MB")
+        print(f"  Delta size:  {round(output_size / (1024**2), 1)} MB")
+
+    sys.exit(result.returncode)
+
+
+def cmd_merge(args):
+    """Merge a child CHD with its parent into a standalone CHD."""
+    child_path = Path(args.child).resolve()
+    output_path = Path(args.output).resolve()
+
+    if not child_path.exists():
+        print(f"Error: Child CHD not found: {child_path}")
+        sys.exit(1)
+
+    cmd = ["copy",
+           "--input", str(child_path),
+           "--output", str(output_path)]
+
+    if args.force:
+        cmd.append("--force")
+
+    print("Merging child CHD into standalone")
+    print(f"  Child:  {child_path}")
+    print(f"  Output: {output_path}")
+
+    if args.dry_run:
+        print(f"[DRY RUN] Would run: chdman {' '.join(cmd)}")
+        return
+
+    result = run_chdman(cmd)
+    print(result.stdout)
+    if result.stderr:
+        print(result.stderr)
+
+    sys.exit(result.returncode)
+
+
+def cmd_batch_create(args):
+    """Convert all matching files in a directory to CHD."""
+    directory = Path(args.directory).resolve()
+    if not directory.is_dir():
+        print(f"Error: Not a directory: {directory}")
+        sys.exit(1)
+
+    extensions = set()
+    if args.format:
+        for fmt in args.format.split(","):
+            ext = fmt.strip().lower()
+            if not ext.startswith("."):
+                ext = "." + ext
+            extensions.add(ext)
+    else:
+        extensions = CONVERTIBLE_EXTENSIONS
+
+    # Find all convertible files
+    files = []
+    for f in sorted(directory.rglob("*")):
+        if f.is_file() and f.suffix.lower() in extensions:
+            chd_path = f.with_suffix(".chd")
+            if not chd_path.exists() or args.force:
+                files.append(f)
+
+    if not files:
+        print(f"No convertible files found in {directory}")
+        print(f"Looking for: {', '.join(sorted(extensions))}")
+        return
+
+    print(f"Found {len(files)} files to convert in {directory}")
+    total_input = sum(f.stat().st_size for f in files)
+    print(f"Total input size: {round(total_input / (1024**3), 2)} GB")
+    print()
+
+    if args.dry_run:
+        for f in files:
+            print(f"  [DRY RUN] {f.name} -> {f.stem}.chd")
+        return
+
+    converted = 0
+    failed = 0
+    total_saved = 0
+
+    for i, f in enumerate(files, 1):
+        chd_path = f.with_suffix(".chd")
+        print(f"[{i}/{len(files)}] {f.name}")
+
+        ext = f.suffix.lower()
+        if ext in (".cue", ".gdi", ".toc"):
+            subcmd = "createcd"
+        else:
+            subcmd = "createraw"
+            hunk_args = ["--hunksize", "2048"]
+
+        cmd = [subcmd, "--input", str(f), "--output", str(chd_path)]
+        if subcmd == "createraw":
+            cmd.extend(hunk_args)
+
+        result = run_chdman(cmd)
+
+        if result.returncode == 0 and chd_path.exists():
+            input_size = f.stat().st_size
+            output_size = chd_path.stat().st_size
+            saved = input_size - output_size
+            total_saved += saved
+            ratio = round(output_size / input_size * 100, 1) if input_size > 0 else 0
+            print(f"  OK — {ratio}% ({round(saved / (1024**2), 1)} MB saved)")
+            converted += 1
+
+            if args.delete_originals:
+                # For cue/gdi, also delete the referenced bin/track files
+                if ext == ".cue":
+                    delete_cue_files(f)
+                elif ext == ".gdi":
+                    delete_gdi_files(f)
+                f.unlink()
+                print("  Deleted original")
+        else:
+            print(f"  FAILED: {result.stderr.strip()}")
+            failed += 1
+
+    print(f"\nBatch complete: {converted} converted, {failed} failed")
+    print(f"Total space saved: {round(total_saved / (1024**3), 2)} GB")
+
+
+def cmd_batch_verify(args):
+    """Verify all CHD files in a directory."""
+    directory = Path(args.directory).resolve()
+    if not directory.is_dir():
+        print(f"Error: Not a directory: {directory}")
+        sys.exit(1)
+
+    files = sorted(directory.rglob("*.chd"))
+    if not files:
+        print(f"No CHD files found in {directory}")
+        return
+
+    print(f"Verifying {len(files)} CHD files in {directory}")
+    print()
+
+    passed = 0
+    failed = 0
+    errors = []
+
+    for i, f in enumerate(files, 1):
+        result = run_chdman(["verify", "--input", str(f)])
+        if result.returncode == 0:
+            print(f"  [{i}/{len(files)}] PASS — {f.name}")
+            passed += 1
+        else:
+            print(f"  [{i}/{len(files)}] FAIL — {f.name}")
+            errors.append(str(f))
+            failed += 1
+
+    print(f"\nResults: {passed} passed, {failed} failed")
+    if errors:
+        print("Failed files:")
+        for e in errors:
+            print(f"  {e}")
+
+    if args.json:
+        summary = {
+            "directory": str(directory),
+            "total": len(files),
+            "passed": passed,
+            "failed": failed,
+            "failed_files": errors,
+            "timestamp": datetime.now().isoformat(),
+        }
+        print(json.dumps(summary, indent=2))
+
+
+def cmd_compare(args):
+    """Compare two CHD files."""
+    file1 = Path(args.file1).resolve()
+    file2 = Path(args.file2).resolve()
+
+    info1 = get_chd_info(file1)
+    info2 = get_chd_info(file2)
+
+    if info1 and info2:
+        print(f"File 1: {file1.name}")
+        print(f"  Size: {round(file1.stat().st_size / (1024**2), 1)} MB")
+        print(f"  SHA1: {info1.get('sha1', 'unknown')}")
+        print()
+        print(f"File 2: {file2.name}")
+        print(f"  Size: {round(file2.stat().st_size / (1024**2), 1)} MB")
+        print(f"  SHA1: {info2.get('sha1', 'unknown')}")
+        print()
+
+        if info1.get("sha1") and info2.get("sha1"):
+            if info1["sha1"] == info2["sha1"]:
+                print("MATCH — identical content")
+            else:
+                print("DIFFERENT — content differs")
+
+
+def cmd_convert(args):
+    """Re-compress a CHD with different settings."""
+    input_path = Path(args.input).resolve()
+    output_path = Path(args.output).resolve()
+
+    if not input_path.exists():
+        print(f"Error: File not found: {input_path}")
+        sys.exit(1)
+
+    cmd = ["copy", "--input", str(input_path), "--output", str(output_path)]
+
+    if args.compression and args.compression in COMPRESSION_PRESETS:
+        cmd.extend(COMPRESSION_PRESETS[args.compression])
+    elif args.compression:
+        cmd.extend(["--compression", args.compression])
+
+    if args.force:
+        cmd.append("--force")
+
+    input_size = input_path.stat().st_size
+    print(f"Re-compressing: {input_path}")
+    print(f"Output: {output_path}")
+
+    if args.dry_run:
+        print(f"[DRY RUN] Would run: chdman {' '.join(cmd)}")
+        return
+
+    result = run_chdman(cmd)
+    print(result.stdout)
+    if result.stderr:
+        print(result.stderr)
+
+    if result.returncode == 0 and output_path.exists():
+        output_size = output_path.stat().st_size
+        print(f"\n  Before: {round(input_size / (1024**2), 1)} MB")
+        print(f"  After:  {round(output_size / (1024**2), 1)} MB")
+        diff = input_size - output_size
+        if diff > 0:
+            print(f"  Saved:  {round(diff / (1024**2), 1)} MB")
+        elif diff < 0:
+            print(f"  Grew:   {round(abs(diff) / (1024**2), 1)} MB (worse compression)")
+
+    sys.exit(result.returncode)
+
+
+def cmd_import(args):
+    """Convert any supported disc image format to CHD, handling intermediate conversions."""
+    input_path = Path(args.input).resolve()
+    output_path = Path(args.output).resolve() if args.output else input_path.with_suffix(".chd")
+
+    if not input_path.exists():
+        print(f"Error: File not found: {input_path}")
+        sys.exit(1)
+
+    ext = input_path.suffix.lower()
+
+    # Formats chdman handles directly
+    native_formats = {".iso", ".img", ".bin", ".raw", ".cue", ".gdi", ".toc"}
+
+    # Formats that need intermediate conversion
+    converters = {
+        ".cso": ("maxcso", ["--decompress", str(input_path)], ".iso"),
+        ".zso": ("maxcso", ["--decompress", str(input_path)], ".iso"),
+        ".dax": ("maxcso", ["--decompress", str(input_path)], ".iso"),
+        ".pbp": ("pbp2iso", [str(input_path)], ".iso"),
+        ".nrg": ("nrg2iso", [str(input_path)], ".iso"),
+        ".mdf": ("mdf2iso", [str(input_path)], ".iso"),
+        ".ecm": ("ecm2bin", [str(input_path)], ".bin"),
+        ".ape": ("ffmpeg", ["-i", str(input_path), "-f", "wav"], ".wav"),
+        ".7z":  ("7z", ["x", str(input_path), f"-o{input_path.parent}"], None),
+        ".zip": ("7z", ["x", str(input_path), f"-o{input_path.parent}"], None),
+        ".rar": ("7z", ["x", str(input_path), f"-o{input_path.parent}"], None),
+        ".gz":  ("7z", ["x", str(input_path), f"-o{input_path.parent}"], None),
+    }
+
+    if ext in native_formats:
+        # Direct conversion
+        print(f"Format {ext} is natively supported — creating CHD directly")
+        args_obj = argparse.Namespace(
+            input=str(input_path), output=str(output_path),
+            compression=args.compression, hunk_size=None,
+            force=args.force, dry_run=args.dry_run
+        )
+        cmd_create(args_obj)
+        return
+
+    if ext not in converters:
+        print(f"Error: Unsupported format: {ext}")
+        print(f"Supported formats: {', '.join(sorted(native_formats | set(converters.keys())))}")
+        sys.exit(1)
+
+    tool_name, tool_args, intermediate_ext = converters[ext]
+
+    # Check if conversion tool is available
+    tool_path = shutil.which(tool_name)
+    wsl_fallback = False
+    if not tool_path:
+        result = subprocess.run(["wsl", "which", tool_name], capture_output=True, text=True)
+        if result.returncode == 0 and result.stdout.strip():
+            wsl_fallback = True
+        else:
+            print(f"Error: {tool_name} not found.")
+            print(f"Required to convert {ext} files.")
+            print(f"Install {tool_name} and try again.")
+            sys.exit(2)
+
+    # Archives need special handling — extract then find the image inside
+    if ext in (".7z", ".zip", ".rar", ".gz"):
+        print("Archive detected — extracting first")
+        if args.dry_run:
+            print(f"[DRY RUN] Would extract {input_path} and convert contents")
+            return
+
+        if wsl_fallback:
+            cmd = ["wsl", tool_name] + tool_args
+        else:
+            cmd = [tool_name] + tool_args
+
+        result = subprocess.run(cmd)
+        if result.returncode != 0:
+            print(f"Error: Failed to extract {input_path}")
+            sys.exit(1)
+
+        # Find extracted image files
+        found = []
+        for f in input_path.parent.iterdir():
+            if f.suffix.lower() in native_formats and f.stem != input_path.stem:
+                found.append(f)
+
+        if not found:
+            # Check for nested convertible formats
+            for f in input_path.parent.iterdir():
+                if f.suffix.lower() in converters:
+                    found.append(f)
+
+        if not found:
+            print("Error: No disc image found in archive")
+            sys.exit(1)
+
+        for f in found:
+            chd_out = f.with_suffix(".chd")
+            print(f"Converting extracted: {f.name}")
+            import_args = argparse.Namespace(
+                input=str(f), output=str(chd_out),
+                compression=args.compression, force=args.force,
+                dry_run=False, keep_intermediate=args.keep_intermediate
+            )
+            cmd_import(import_args)
+        return
+
+    # Standard intermediate conversion
+    intermediate_path = input_path.with_suffix(intermediate_ext)
+
+    print(f"Step 1: {ext} → {intermediate_ext} (using {tool_name})")
+
+    if args.dry_run:
+        print(f"[DRY RUN] Would run: {tool_name} {' '.join(tool_args)}")
+        print(f"[DRY RUN] Then: chdman create {intermediate_path} → {output_path}")
+        return
+
+    # Run the intermediate converter
+    if wsl_fallback:
+        cmd = ["wsl", tool_name] + tool_args
+    else:
+        cmd = [tool_name] + tool_args
+
+    # Some tools need the output path appended
+    if tool_name in ("nrg2iso", "mdf2iso", "pbp2iso", "ecm2bin"):
+        cmd.append(str(intermediate_path))
+
+    result = subprocess.run(cmd)
+    if result.returncode != 0:
+        print(f"Error: {tool_name} failed")
+        sys.exit(1)
+
+    if not intermediate_path.exists():
+        # maxcso replaces the file in-place with new extension
+        possible = input_path.with_suffix(intermediate_ext)
+        if possible.exists():
+            intermediate_path = possible
+        else:
+            print(f"Error: Expected intermediate file not found: {intermediate_path}")
+            sys.exit(1)
+
+    print(f"Step 2: {intermediate_ext} → .chd (using chdman)")
+
+    create_args = argparse.Namespace(
+        input=str(intermediate_path), output=str(output_path),
+        compression=args.compression, hunk_size=None,
+        force=args.force, dry_run=False
+    )
+    cmd_create(create_args)
+
+    # Clean up intermediate file unless told to keep it
+    if not args.keep_intermediate and intermediate_path.exists():
+        intermediate_path.unlink()
+        print(f"Cleaned up intermediate: {intermediate_path.name}")
+
+
+def cmd_batch_import(args):
+    """Convert all disc images in a directory to CHD, handling any format."""
+    directory = Path(args.directory).resolve()
+    if not directory.is_dir():
+        print(f"Error: Not a directory: {directory}")
+        sys.exit(1)
+
+    all_supported = CONVERTIBLE_EXTENSIONS | {".cso", ".zso", ".dax", ".pbp", ".nrg",
+                                                ".mdf", ".ecm", ".7z", ".zip", ".rar", ".gz"}
+
+    extensions = set()
+    if args.format:
+        for fmt in args.format.split(","):
+            ext = fmt.strip().lower()
+            if not ext.startswith("."):
+                ext = "." + ext
+            extensions.add(ext)
+    else:
+        extensions = all_supported
+
+    files = []
+    for f in sorted(directory.rglob("*")):
+        if f.is_file() and f.suffix.lower() in extensions:
+            chd_path = f.with_suffix(".chd")
+            if not chd_path.exists() or args.force:
+                files.append(f)
+
+    if not files:
+        print(f"No convertible files found in {directory}")
+        return
+
+    print(f"Found {len(files)} files to import in {directory}")
+    print()
+
+    converted = 0
+    failed = 0
+
+    for i, f in enumerate(files, 1):
+        print(f"\n[{i}/{len(files)}] {f.name}")
+        try:
+            import_args = argparse.Namespace(
+                input=str(f), output=None,
+                compression=args.compression, force=args.force,
+                dry_run=args.dry_run, keep_intermediate=args.keep_intermediate
+            )
+            cmd_import(import_args)
+            converted += 1
+
+            if args.delete_originals and not args.dry_run:
+                f.unlink()
+                print(f"  Deleted original: {f.name}")
+        except SystemExit as e:
+            if e.code != 0:
+                failed += 1
+        except Exception as e:
+            print(f"  Error: {e}")
+            failed += 1
+
+    print(f"\nBatch import complete: {converted} converted, {failed} failed")
+
+
+def cmd_import_tools(args):
+    """Show status of all format conversion tools."""
+    print("Import tool status:")
+    print()
+    for tool, description in IMPORT_TOOLS.items():
+        path = shutil.which(tool)
+        if path:
+            status = f"INSTALLED ({path})"
+        else:
+            # Check WSL
+            result = subprocess.run(["wsl", "which", tool],
+                                    capture_output=True, text=True)
+            if result.returncode == 0 and result.stdout.strip():
+                status = f"INSTALLED (WSL: {result.stdout.strip()})"
+            else:
+                status = "NOT INSTALLED"
+
+        marker = "+" if "INSTALLED" in status and "NOT" not in status else "-"
+        print(f"  {marker} {tool:15s} {status}")
+        print(f"    {description}")
+        print()
+
+
+IMPORT_TOOLS = {
+    "maxcso": "PSP: CSO/ZSO/DAX decompression (apt install maxcso OR github.com/unknownbrackets/maxcso)",
+    "pbp2iso": "PSP: PBP to ISO (github.com/pspdev/pspsdk)",
+    "nrg2iso": "Nero: NRG to ISO (apt install nrg2iso)",
+    "mdf2iso": "Alcohol: MDF to ISO (apt install mdf2iso)",
+    "ecm2bin": "ECM: error code modeler decode (apt install ecm)",
+    "ffmpeg": "Audio: various audio format conversion (apt install ffmpeg)",
+    "7z": "Archives: 7z/zip/rar/gz extraction (apt install p7zip-full)",
+}
+
+
+def get_chd_info(chd_path):
+    """Parse chdman info output into a dict."""
+    result = run_chdman(["info", "--verbose", "--input", str(chd_path)])
+    if result.returncode != 0:
+        return None
+
+    info = {}
+    for line in result.stdout.splitlines():
+        if ":" in line:
+            key, _, value = line.partition(":")
+            info[key.strip().lower().replace(" ", "_")] = value.strip()
+    return info
+
+
+def delete_cue_files(cue_path):
+    """Delete bin files referenced by a cue sheet."""
+    try:
+        with open(cue_path) as f:
+            for line in f:
+                if line.strip().upper().startswith("FILE"):
+                    parts = line.strip().split('"')
+                    if len(parts) >= 2:
+                        bin_file = cue_path.parent / parts[1]
+                        if bin_file.exists():
+                            bin_file.unlink()
+    except Exception:
+        pass
+
+
+def delete_gdi_files(gdi_path):
+    """Delete track files referenced by a GDI file."""
+    try:
+        with open(gdi_path) as f:
+            for line in f:
+                parts = line.strip().split()
+                if len(parts) >= 5:
+                    track_file = gdi_path.parent / parts[4]
+                    if track_file.exists():
+                        track_file.unlink()
+    except Exception:
+        pass
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="CHD archive management — create, verify, extract, diff, batch convert.",
+    )
+    subparsers = parser.add_subparsers(dest="command", help="Command to run")
+
+    # create
+    p = subparsers.add_parser("create", help="Create CHD from disc image or raw dump")
+    p.add_argument("input", help="Input file (.iso, .img, .bin, .cue, .gdi, .raw)")
+    p.add_argument("output", help="Output CHD file")
+    p.add_argument("--compression", choices=list(COMPRESSION_PRESETS.keys()),
+                    help="Compression preset")
+    p.add_argument("--hunk-size", help="Hunk size in bytes (default: auto)")
+    p.add_argument("--force", action="store_true", help="Overwrite existing output")
+    p.add_argument("--dry-run", action="store_true")
+
+    # verify
+    p = subparsers.add_parser("verify", help="Verify CHD integrity")
+    p.add_argument("file", help="CHD file to verify")
+
+    # extract
+    p = subparsers.add_parser("extract", help="Extract CHD to raw format")
+    p.add_argument("file", help="CHD file to extract")
+    p.add_argument("output", help="Output file")
+    p.add_argument("--force", action="store_true")
+    p.add_argument("--dry-run", action="store_true")
+
+    # info
+    p = subparsers.add_parser("info", help="Show CHD metadata")
+    p.add_argument("file", help="CHD file")
+    p.add_argument("--json", action="store_true", help="Output as JSON")
+
+    # delta
+    p = subparsers.add_parser("delta", help="Create delta (child) CHD from parent")
+    p.add_argument("parent", help="Parent CHD file")
+    p.add_argument("input", help="Input file for child")
+    p.add_argument("output", help="Output child CHD file")
+    p.add_argument("--dry-run", action="store_true")
+
+    # merge
+    p = subparsers.add_parser("merge", help="Merge child CHD into standalone")
+    p.add_argument("child", help="Child CHD file")
+    p.add_argument("output", help="Output standalone CHD file")
+    p.add_argument("--force", action="store_true")
+    p.add_argument("--dry-run", action="store_true")
+
+    # batch-create
+    p = subparsers.add_parser("batch-create", help="Convert all matching files in a directory")
+    p.add_argument("directory", help="Directory to scan")
+    p.add_argument("--format", help="File extensions to convert (comma-separated, e.g., iso,bin,cue)")
+    p.add_argument("--delete-originals", action="store_true",
+                    help="Delete original files after successful conversion")
+    p.add_argument("--force", action="store_true", help="Overwrite existing CHDs")
+    p.add_argument("--dry-run", action="store_true")
+
+    # batch-verify
+    p = subparsers.add_parser("batch-verify", help="Verify all CHDs in a directory")
+    p.add_argument("directory", help="Directory to scan")
+    p.add_argument("--json", action="store_true", help="Output summary as JSON")
+
+    # import (convert any format to CHD)
+    p = subparsers.add_parser("import", help="Convert any disc image format to CHD")
+    p.add_argument("input", help="Input file (ISO, CSO, PBP, NRG, MDF, ECM, CUE, GDI, 7z, zip, etc.)")
+    p.add_argument("output", nargs="?", help="Output CHD file (default: same name with .chd)")
+    p.add_argument("--compression", choices=list(COMPRESSION_PRESETS.keys()))
+    p.add_argument("--force", action="store_true")
+    p.add_argument("--keep-intermediate", action="store_true",
+                    help="Don't delete intermediate files after conversion")
+    p.add_argument("--dry-run", action="store_true")
+
+    # batch-import
+    p = subparsers.add_parser("batch-import", help="Convert all disc images in a directory to CHD")
+    p.add_argument("directory", help="Directory to scan")
+    p.add_argument("--format", help="File extensions to convert (comma-separated)")
+    p.add_argument("--compression", choices=list(COMPRESSION_PRESETS.keys()))
+    p.add_argument("--delete-originals", action="store_true")
+    p.add_argument("--keep-intermediate", action="store_true")
+    p.add_argument("--force", action="store_true")
+    p.add_argument("--dry-run", action="store_true")
+
+    # import-tools (show required tools)
+    p = subparsers.add_parser("import-tools", help="Show required tools for format conversion")
+
+    # compare
+    p = subparsers.add_parser("compare", help="Compare two CHD files")
+    p.add_argument("file1", help="First CHD file")
+    p.add_argument("file2", help="Second CHD file")
+
+    # convert
+    p = subparsers.add_parser("convert", help="Re-compress CHD with different settings")
+    p.add_argument("input", help="Input CHD file")
+    p.add_argument("output", help="Output CHD file")
+    p.add_argument("--compression", choices=list(COMPRESSION_PRESETS.keys()),
+                    help="Compression preset")
+    p.add_argument("--force", action="store_true")
+    p.add_argument("--dry-run", action="store_true")
+
+    args = parser.parse_args()
+
+    if not args.command:
+        parser.print_help()
+        sys.exit(0)
+
+    commands = {
+        "create": cmd_create,
+        "verify": cmd_verify,
+        "extract": cmd_extract,
+        "info": cmd_info,
+        "delta": cmd_delta,
+        "merge": cmd_merge,
+        "batch-create": cmd_batch_create,
+        "batch-verify": cmd_batch_verify,
+        "compare": cmd_compare,
+        "convert": cmd_convert,
+        "import": cmd_import,
+        "batch-import": cmd_batch_import,
+        "import-tools": cmd_import_tools,
+    }
+
+    commands[args.command](args)
+
+
+if __name__ == "__main__":
+    main()

--- a/image-disk.py
+++ b/image-disk.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python
+"""
+JP_TOOLS/image-disk.py
+Create a forensic disk image using ddrescue.
+
+ddrescue is fault-tolerant — it handles bad sectors, retries intelligently,
+and keeps a log so you can resume interrupted imaging.
+
+Usage:
+    python image-disk.py <source> <output.img> [--log <logfile>] [--dry-run]
+
+Source can be:
+    /dev/sdX        — block device (Linux)
+    F:              — Windows drive letter (runs via WSL)
+
+Examples:
+    python image-disk.py /dev/sdb ~/images/drive.img
+    python image-disk.py F: D:/images/drive.img
+    python image-disk.py /dev/sdb ~/images/drive.img --log ~/images/drive.log
+"""
+
+import os
+import sys
+import shutil
+import subprocess
+import argparse
+import ctypes
+from pathlib import Path
+from datetime import datetime
+
+
+def is_admin():
+    try:
+        return ctypes.windll.shell32.IsUserAnAdmin()
+    except AttributeError:
+        return os.geteuid() == 0
+
+
+def win_to_wsl_path(win_path):
+    """Convert C:\\foo\\bar to /mnt/c/foo/bar."""
+    p = str(win_path)
+    if len(p) >= 2 and p[1] == ":":
+        return f"/mnt/{p[0].lower()}/{p[2:].replace(chr(92), '/')}"
+    return p.replace("\\", "/")
+
+
+def resolve_source(source):
+    """Resolve Windows drive letter to WSL device path."""
+    if len(source) <= 3 and source[0].isalpha() and source.endswith(":"):
+        letter = source[0].upper()
+        result = subprocess.run(
+            ["powershell", "-Command",
+             f"Get-Partition -DriveLetter {letter} | "
+             f"Select-Object -ExpandProperty DiskNumber"],
+            capture_output=True, text=True
+        )
+        if result.returncode == 0 and result.stdout.strip().isdigit():
+            disk_num = result.stdout.strip()
+            # WSL maps Windows disks — but USB drives aren't usually visible.
+            # We need usbipd or to use the Windows \\.\PhysicalDriveN path.
+            print(f"Detected {source} as PhysicalDrive{disk_num}")
+            print()
+            print("For WSL ddrescue, the drive must be attached to WSL via usbipd,")
+            print("or you can use the native Linux boot approach.")
+            print()
+            print("To attach via usbipd:")
+            print("  usbipd list")
+            print("  usbipd bind --busid <BUSID>")
+            print("  usbipd attach --wsl --busid <BUSID>")
+            print("Then run again with the /dev/sdX device.")
+            print()
+            print("Or boot a Linux live USB and run:")
+            print(f"  ddrescue /dev/sdX {source}.img {source}.log")
+            sys.exit(1)
+        else:
+            print(f"Error: Could not find physical drive for {source}")
+            sys.exit(1)
+
+    return source
+
+
+def find_ddrescue():
+    """Find ddrescue binary."""
+    for name in ("ddrescue", "gddrescue"):
+        path = shutil.which(name)
+        if path:
+            return [path]
+
+    # Try WSL
+    result = subprocess.run(
+        ["wsl", "which", "ddrescue"],
+        capture_output=True, text=True
+    )
+    if result.returncode == 0 and result.stdout.strip():
+        return ["wsl", result.stdout.strip()]
+
+    return None
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Create a forensic disk image using ddrescue.",
+    )
+    parser.add_argument("source", help="Device or drive letter to image")
+    parser.add_argument("output", help="Output image file path")
+    parser.add_argument("--log", help="ddrescue log file (enables resume). "
+                        "Defaults to <output>.log")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Show what would be done without imaging")
+    parser.add_argument("--no-scrape", action="store_true",
+                        help="Skip the scraping pass (faster, may miss bad sectors)")
+    args = parser.parse_args()
+
+    ddrescue = find_ddrescue()
+    if not ddrescue:
+        print("Error: ddrescue not found.")
+        print("Install with:")
+        print("  Ubuntu/Debian: sudo apt install gddrescue")
+        print("  macOS: brew install ddrescue")
+        sys.exit(2)
+
+    source = resolve_source(args.source)
+    output = Path(args.output).resolve()
+    log_file = Path(args.log).resolve() if args.log else output.with_suffix(".log")
+
+    output.parent.mkdir(parents=True, exist_ok=True)
+
+    # Convert paths for WSL if needed
+    if ddrescue[0] == "wsl":
+        out_path = win_to_wsl_path(output)
+        log_path = win_to_wsl_path(log_file)
+    else:
+        out_path = str(output)
+        log_path = str(log_file)
+
+    print(f"Source:  {source}")
+    print(f"Output:  {output}")
+    print(f"Log:     {log_file}")
+    print()
+
+    if args.dry_run:
+        print("[DRY RUN] No image created.")
+        return
+
+    # Check if we need elevation (Linux)
+    if source.startswith("/dev/") and not is_admin():
+        if ddrescue[0] == "wsl":
+            ddrescue = ["wsl", "sudo", "ddrescue"]
+        else:
+            print("Error: Reading block devices requires root. Run with sudo.")
+            sys.exit(1)
+
+    start = datetime.now()
+
+    # First pass — fast copy of good sectors
+    cmd = ddrescue + ["-f", "-n", source, out_path, log_path]
+    print(f"Pass 1 (fast copy): {' '.join(cmd)}")
+    result = subprocess.run(cmd)
+
+    if result.returncode != 0:
+        print(f"\nFirst pass failed with exit code {result.returncode}")
+        sys.exit(result.returncode)
+
+    # Second pass — scrape bad sectors (retry)
+    if not args.no_scrape:
+        cmd = ddrescue + ["-f", "-d", "-r", "3", source, out_path, log_path]
+        print(f"\nPass 2 (scrape): {' '.join(cmd)}")
+        result = subprocess.run(cmd)
+
+    elapsed = (datetime.now() - start).total_seconds()
+    size = output.stat().st_size if output.exists() else 0
+
+    print("\nImaging complete:")
+    print(f"  Size:    {round(size / (1024**3), 1)} GB")
+    print(f"  Elapsed: {round(elapsed, 1)}s")
+    print(f"  Image:   {output}")
+    print(f"  Log:     {log_file}")
+    print("\nRecover files with:")
+    print(f"  python recover.py {output} ./recovered --profile all")
+
+
+if __name__ == "__main__":
+    main()

--- a/install-recovery.ps1
+++ b/install-recovery.ps1
@@ -1,0 +1,89 @@
+# JP_TOOLS recovery tools installer (Windows)
+# Downloads and extracts Windows-native recovery and forensics tools.
+# Run from PowerShell (admin not required for download/extract).
+
+$ErrorActionPreference = "Stop"
+$toolsDir = Join-Path $env:USERPROFILE "tools"
+
+Write-Host "==> JP_TOOLS Recovery Tools Installer (Windows)" -ForegroundColor Cyan
+Write-Host ""
+
+# --- TestDisk / PhotoRec ---
+$testdiskDir = Join-Path $toolsDir "testdisk"
+if (Test-Path (Join-Path $testdiskDir "testdisk-7.1\photorec_win.exe")) {
+    Write-Host "  + testdisk/photorec already installed" -ForegroundColor Green
+} else {
+    Write-Host "  Installing testdisk/photorec..."
+    $url = "https://www.cgsecurity.org/testdisk-7.1.win64.zip"
+    $zip = Join-Path $env:TEMP "testdisk-7.1.win64.zip"
+    New-Item -ItemType Directory -Path $testdiskDir -Force | Out-Null
+    Invoke-WebRequest -Uri $url -OutFile $zip
+    Expand-Archive -Path $zip -DestinationPath $testdiskDir -Force
+    Remove-Item $zip
+    Write-Host "  + testdisk/photorec installed" -ForegroundColor Green
+}
+
+# --- Sleuth Kit ---
+$sleuthkitDir = Join-Path $toolsDir "sleuthkit"
+if (Test-Path (Join-Path $sleuthkitDir "sleuthkit-4.14.0-win32\bin\fls.exe")) {
+    Write-Host "  + sleuthkit already installed" -ForegroundColor Green
+} else {
+    Write-Host "  Installing sleuthkit..."
+    $url = "https://github.com/sleuthkit/sleuthkit/releases/download/sleuthkit-4.14.0/sleuthkit-4.14.0-win32.zip"
+    $zip = Join-Path $env:TEMP "sleuthkit-4.14.0-win32.zip"
+    New-Item -ItemType Directory -Path $sleuthkitDir -Force | Out-Null
+    Invoke-WebRequest -Uri $url -OutFile $zip
+    Expand-Archive -Path $zip -DestinationPath $sleuthkitDir -Force
+    Remove-Item $zip
+    Write-Host "  + sleuthkit installed" -ForegroundColor Green
+}
+
+# --- MAME / chdman ---
+$mameDir = Join-Path $toolsDir "mame"
+if (Test-Path (Join-Path $mameDir "chdman.exe")) {
+    Write-Host "  + chdman already installed" -ForegroundColor Green
+} else {
+    Write-Host "  Installing MAME (for chdman)..."
+    $latestRelease = Invoke-RestMethod -Uri "https://api.github.com/repos/mamedev/mame/releases/latest"
+    $asset = $latestRelease.assets | Where-Object { $_.name -match "x64\.exe$" } | Select-Object -First 1
+    if ($asset) {
+        $exe = Join-Path $env:TEMP $asset.name
+        Invoke-WebRequest -Uri $asset.browser_download_url -OutFile $exe
+        New-Item -ItemType Directory -Path $mameDir -Force | Out-Null
+        Start-Process -FilePath $exe -ArgumentList "-o`"$mameDir`" -y" -Wait -NoNewWindow
+        Remove-Item $exe
+        Write-Host "  + chdman installed" -ForegroundColor Green
+    } else {
+        Write-Host "  - Could not find MAME x64 release" -ForegroundColor Red
+    }
+}
+
+# --- Verify ---
+Write-Host ""
+Write-Host "==> Verifying installed tools" -ForegroundColor Cyan
+
+$tools = @(
+    @{ Name = "photorec"; Path = Join-Path $testdiskDir "testdisk-7.1\photorec_win.exe" },
+    @{ Name = "testdisk"; Path = Join-Path $testdiskDir "testdisk-7.1\testdisk_win.exe" },
+    @{ Name = "qphotorec"; Path = Join-Path $testdiskDir "testdisk-7.1\qphotorec_win.exe" },
+    @{ Name = "fls"; Path = Join-Path $sleuthkitDir "sleuthkit-4.14.0-win32\bin\fls.exe" },
+    @{ Name = "icat"; Path = Join-Path $sleuthkitDir "sleuthkit-4.14.0-win32\bin\icat.exe" },
+    @{ Name = "mmls"; Path = Join-Path $sleuthkitDir "sleuthkit-4.14.0-win32\bin\mmls.exe" },
+    @{ Name = "img_stat"; Path = Join-Path $sleuthkitDir "sleuthkit-4.14.0-win32\bin\img_stat.exe" },
+    @{ Name = "fidentify"; Path = Join-Path $testdiskDir "testdisk-7.1\fidentify_win.exe" },
+    @{ Name = "chdman"; Path = Join-Path $mameDir "chdman.exe" }
+)
+
+foreach ($tool in $tools) {
+    if (Test-Path $tool.Path) {
+        Write-Host "    + $($tool.Name)" -ForegroundColor Green
+    } else {
+        Write-Host "    - $($tool.Name) (not found)" -ForegroundColor Red
+    }
+}
+
+Write-Host ""
+Write-Host "==> WSL tools (optional, for additional capabilities)" -ForegroundColor Cyan
+Write-Host "  Run install-recovery.sh inside WSL for: foremost, ddrescue, binwalk, chdman, scalpel"
+Write-Host ""
+Write-Host "Done." -ForegroundColor Green

--- a/install-recovery.sh
+++ b/install-recovery.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+# JP_TOOLS recovery tools installer
+# Installs data recovery and forensics tools.
+# Run directly on Linux, or via WSL on Windows.
+set -e
+
+echo "==> Installing recovery & forensics tools"
+
+# Detect package manager
+if command -v apt &>/dev/null; then
+    PKG="apt"
+    sudo apt update -qq
+
+    echo ""
+    echo "--- File recovery / carving ---"
+    sudo apt install -y testdisk       # photorec + testdisk
+    sudo apt install -y foremost       # alternative file carver
+    sudo apt install -y scalpel        # configurable file carver
+
+    echo ""
+    echo "--- Disk imaging ---"
+    sudo apt install -y gddrescue      # ddrescue — fault-tolerant dd
+
+    echo ""
+    echo "--- Filesystem recovery ---"
+    sudo apt install -y ntfs-3g        # includes ntfsundelete
+    sudo apt install -y extundelete 2>/dev/null || echo "    extundelete not available in this repo — skipping"
+
+    echo ""
+    echo "--- Analysis / forensics ---"
+    sudo apt install -y sleuthkit      # filesystem forensics (fls, icat, etc.)
+    sudo apt install -y binwalk        # embedded file/firmware scanner
+
+    echo ""
+    echo "--- Compressed storage ---"
+    sudo apt install -y mame-tools     # chdman — CHD create/verify/extract/diff
+
+    echo ""
+    echo "--- Format converters (for CHD import pipeline) ---"
+    sudo apt install -y nrg2iso        # Nero image converter
+    sudo apt install -y mdf2iso        # Alcohol 120% image converter
+    sudo apt install -y ecm            # ECM error code modeler (ecm2bin)
+    sudo apt install -y p7zip-full     # 7z archive extraction
+    sudo apt install -y ffmpeg         # audio/video format conversion
+    sudo apt install -y maxcso 2>/dev/null || echo "    maxcso not in repo — install from github.com/unknownbrackets/maxcso"
+
+elif command -v dnf &>/dev/null; then
+    PKG="dnf"
+    sudo dnf install -y testdisk foremost ddrescue ntfs-3g sleuthkit binwalk
+
+elif command -v pacman &>/dev/null; then
+    PKG="pacman"
+    sudo pacman -S --noconfirm testdisk foremost ddrescue ntfs-3g sleuthkit binwalk
+
+elif command -v brew &>/dev/null; then
+    PKG="brew"
+    brew install testdisk foremost ddrescue sleuthkit binwalk
+
+else
+    echo "Error: No supported package manager found (apt, dnf, pacman, brew)"
+    exit 1
+fi
+
+echo ""
+echo "==> Windows-native tools"
+# Check if we're in WSL and native testdisk exists
+WIN_TESTDISK="$HOME/tools/testdisk/testdisk-7.1/photorec_win.exe"
+if [ -f "/mnt/c/Users/jpari/tools/testdisk/testdisk-7.1/photorec_win.exe" ]; then
+    echo "    Native Windows photorec found at ~/tools/testdisk/"
+elif [ -f "$WIN_TESTDISK" ]; then
+    echo "    Native Windows photorec found at $WIN_TESTDISK"
+else
+    echo "    Native Windows photorec not found."
+    echo "    Download from: https://www.cgsecurity.org/wiki/TestDisk_Download"
+    echo "    Extract to: ~/tools/testdisk/"
+fi
+
+echo ""
+echo "==> Verifying installed tools"
+TOOLS="photorec testdisk foremost ddrescue ntfsundelete fls binwalk chdman nrg2iso mdf2iso ecm2bin 7z ffmpeg"
+for tool in $TOOLS; do
+    if command -v "$tool" &>/dev/null; then
+        echo "    ✓ $tool"
+    else
+        echo "    ✗ $tool (not found)"
+    fi
+done
+
+# Optional: scalpel, extundelete
+for tool in scalpel extundelete; do
+    if command -v "$tool" &>/dev/null; then
+        echo "    ✓ $tool"
+    else
+        echo "    - $tool (optional, not installed)"
+    fi
+done
+
+echo ""
+echo "Done. Recovery tools ready."
+echo ""
+echo "Usage:"
+echo "  python recover.py <source> <output> --profile <code|art|writing|roms|all|full>"
+echo "  python recover.py <source> --image <output.img>"
+echo "  python recover.py --list-profiles"

--- a/recover.py
+++ b/recover.py
@@ -1,0 +1,513 @@
+#!/usr/bin/env python
+"""
+JP_TOOLS/recover.py
+Scan a drive or disk image for recoverable files using photorec.
+
+Wraps photorec (from testdisk package) with sensible defaults for
+recovering code, art, documents, and other project files.
+
+Usage:
+    python recover.py <source> <output-dir> [--profile <profile>] [--dry-run] [--list-profiles]
+
+Source can be:
+    /dev/sdX        — raw block device
+    /dev/sdX1       — partition
+    disk.img        — raw disk image file
+    F:              — Windows drive letter (auto-mapped via WSL)
+
+Profiles:
+    code        — JS, HTML, PHP, Python, JSON, XML, CSS, SQL, shell scripts
+    art         — PNG, JPG, TIFF, PSD, BMP, GIF, SVG, WebP
+    writing     — TXT, PDF, DOC/DOCX, ODT, RTF, MD
+    all         — All of the above
+    full        — Everything photorec can find (no filter)
+
+Examples:
+    python recover.py /dev/sdb1 ./recovered --profile code
+    python recover.py F: ./recovered --profile art --dry-run
+    python recover.py disk.img ./recovered --profile all
+"""
+
+import os
+import sys
+import shutil
+import subprocess
+import argparse
+import json
+import ctypes
+from pathlib import Path
+from datetime import datetime
+
+
+def is_admin():
+    """Check if running with admin privileges on Windows."""
+    try:
+        return ctypes.windll.shell32.IsUserAnAdmin()
+    except AttributeError:
+        # Not Windows
+        return os.geteuid() == 0
+
+
+def elevate_and_rerun():
+    """Re-run this script as administrator on Windows."""
+    if sys.platform != "win32":
+        print("Error: This operation requires root. Run with sudo.")
+        sys.exit(1)
+
+    print("Requesting administrator privileges...")
+    params = " ".join(f'"{a}"' for a in sys.argv)
+    ctypes.windll.shell32.ShellExecuteW(
+        None, "runas", sys.executable, params, None, 1
+    )
+
+
+PROFILES = {
+    "code": [
+        "js", "html", "htm", "php", "py", "json", "xml",
+        "css", "sql", "sh", "pl", "rb", "java", "c", "h",
+        "cpp", "cs", "ts", "jsx", "tsx", "vue", "yaml", "yml",
+        "toml", "ini", "conf", "cfg", "env", "gitignore",
+    ],
+    "art": [
+        "png", "jpg", "jpeg", "tiff", "tif", "psd", "bmp",
+        "gif", "svg", "webp", "xcf", "raw", "cr2", "nef",
+        "ico", "ai", "eps",
+    ],
+    "writing": [
+        "txt", "pdf", "doc", "docx", "odt", "rtf", "md",
+        "tex", "epub", "csv", "ods", "xlsx", "xls", "pptx",
+        "wpd",
+    ],
+    "roms": [
+        "nes", "snes", "smc", "sfc", "gb", "gbc", "gba", "nds",
+        "n64", "z64", "v64", "gen", "md", "sms", "gg",
+        "iso", "bin", "cue", "img", "chd", "cso",
+        "a26", "a78", "lnx", "pce", "ngp",
+        "zip", "7z", "rar", "gz",
+    ],
+}
+PROFILES["all"] = PROFILES["code"] + PROFILES["art"] + PROFILES["writing"] + PROFILES["roms"]
+
+
+# photorec file family names — maps our extensions to photorec's internal names
+# photorec uses its own naming; we generate the config to enable only what we want
+PHOTOREC_FAMILIES = {
+    "js": "txt", "html": "html", "htm": "html", "php": "php",
+    "py": "py", "json": "txt", "xml": "xml", "css": "txt",
+    "sql": "txt", "sh": "txt", "pl": "pl", "rb": "rb",
+    "java": "java", "c": "txt", "h": "txt", "cpp": "txt",
+    "cs": "txt", "ts": "txt", "jsx": "txt", "tsx": "txt",
+    "vue": "txt", "yaml": "txt", "yml": "txt", "toml": "txt",
+    "ini": "txt", "conf": "txt", "cfg": "txt", "env": "txt",
+    "gitignore": "txt",
+    "png": "png", "jpg": "jpg", "jpeg": "jpg", "tiff": "tif",
+    "tif": "tif", "psd": "psd", "bmp": "bmp", "gif": "gif",
+    "svg": "svg", "webp": "webp", "xcf": "xcf", "raw": "raw",
+    "cr2": "cr2", "nef": "nef", "ico": "ico", "ai": "ai",
+    "eps": "eps",
+    "wpd": "wpd",
+    "txt": "txt", "pdf": "pdf", "doc": "doc", "docx": "docx",
+    "odt": "odt", "rtf": "rtf", "md": "txt", "tex": "tex",
+    "epub": "epub", "csv": "csv", "ods": "ods", "xlsx": "xlsx",
+    "xls": "xls", "pptx": "pptx",
+}
+
+
+def create_disk_image(source, output_img, dry_run=False):
+    """Create a raw disk image from a drive letter or device.
+
+    Uses dd on Linux or PowerShell on Windows to read the raw disk.
+    """
+    output_path = Path(output_img).resolve()
+
+    # Resolve Windows drive letter to physical drive
+    if len(source) <= 3 and source[0].isalpha() and source.endswith(":"):
+        letter = source[0].upper()
+        result = subprocess.run(
+            ["powershell", "-Command",
+             f"Get-Partition -DriveLetter {letter} | "
+             f"Select-Object -ExpandProperty DiskNumber"],
+            capture_output=True, text=True
+        )
+        if result.returncode != 0 or not result.stdout.strip().isdigit():
+            print(f"Error: Could not find physical drive for {source}")
+            sys.exit(1)
+
+        disk_num = result.stdout.strip()
+
+        # Get disk size
+        result = subprocess.run(
+            ["powershell", "-Command",
+             f"Get-Disk -Number {disk_num} | Select-Object -ExpandProperty Size"],
+            capture_output=True, text=True
+        )
+        disk_size = int(result.stdout.strip()) if result.returncode == 0 else 0
+        size_gb = round(disk_size / (1024**3), 1)
+
+        phys_drive = f"\\\\.\\PhysicalDrive{disk_num}"
+        print(f"Source: {source} -> {phys_drive} ({size_gb} GB)")
+        print(f"Output: {output_path}")
+        print(f"This will create a {size_gb} GB image file.")
+        print()
+
+        if dry_run:
+            print("[DRY RUN] No image created.")
+            return
+
+        # Check for admin privileges
+        if not is_admin():
+            elevate_and_rerun()
+            sys.exit(0)
+
+        # Use WSL dd through the /mnt passthrough
+        # Or use PowerShell's raw disk read
+        print("Creating raw image with dd...")
+        print(f"This will take a while for {size_gb} GB...\n")
+
+        # dd via WSL, reading the Windows physical drive
+        wsl_output = output_path
+        if str(wsl_output)[1] == ":":
+            wsl_output = f"/mnt/{str(output_path)[0].lower()}/{str(output_path)[2:].replace(chr(92), '/')}"
+
+        cmd = [
+            "wsl", "sudo", "dd",
+            f"if=/dev/sd{chr(ord('a') + int(disk_num))}",
+            f"of={wsl_output}",
+            "bs=4M", "status=progress",
+        ]
+        print(f"Running: {' '.join(cmd)}")
+        result = subprocess.run(cmd)
+
+        if result.returncode == 0:
+            actual_size = output_path.stat().st_size if output_path.exists() else 0
+            print(f"\nImage created: {output_path} ({round(actual_size / (1024**3), 1)} GB)")
+            print("Now recover files with:")
+            print(f"  python recover.py {output_path} ./recovered --profile all")
+        else:
+            print(f"\ndd failed with exit code {result.returncode}")
+            print("You may need to run as administrator or use a Linux live USB.")
+        sys.exit(result.returncode)
+    else:
+        # Linux device — straightforward dd
+        print(f"Source: {source}")
+        print(f"Output: {output_path}")
+
+        if dry_run:
+            print("[DRY RUN] No image created.")
+            return
+
+        cmd = ["dd", f"if={source}", f"of={str(output_path)}", "bs=4M", "status=progress"]
+        print(f"Running: {' '.join(cmd)}")
+        result = subprocess.run(cmd)
+        sys.exit(result.returncode)
+
+
+def find_photorec(prefer_native=False):
+    """Find photorec binary — check native Windows, then WSL."""
+    # Check for native Windows photorec (from testdisk package)
+    # Look in common locations
+    native_paths = [
+        Path.home() / "tools" / "testdisk" / "testdisk-7.1" / "photorec_win.exe",
+        Path.home() / "tools" / "testdisk" / "photorec_win.exe",
+    ]
+    for p in native_paths:
+        if p.exists():
+            if prefer_native:
+                return [str(p)], "native"
+            # Still found it, save as fallback
+            native = [str(p)]
+            break
+    else:
+        native = None
+
+    # Direct path (Linux or already on PATH)
+    path = shutil.which("photorec")
+    if path:
+        return [path], "native"
+
+    # Try WSL
+    result = subprocess.run(
+        ["wsl", "which", "photorec"],
+        capture_output=True, text=True
+    )
+    if result.returncode == 0 and result.stdout.strip():
+        return ["wsl", result.stdout.strip()], "wsl"
+
+    # Fall back to native Windows if found earlier
+    if native:
+        return native, "native"
+
+    return None, None
+
+
+def resolve_source(source):
+    """Resolve source to a path photorec understands.
+
+    Handles Windows drive letters (F:) by mapping to /dev/ via WSL.
+    """
+    # Windows drive letter
+    if len(source) <= 3 and source[0].isalpha() and source.endswith(":"):
+        letter = source[0].lower()
+
+        # Try lsblk first (works for native WSL block devices)
+        result = subprocess.run(
+            ["wsl", "bash", "-c",
+             f"lsblk -rno NAME,MOUNTPOINT 2>/dev/null | grep '/mnt/{letter}' | head -1 | cut -d' ' -f1"],
+            capture_output=True, text=True
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            dev = result.stdout.strip()
+            return f"/dev/{dev}"
+
+        # USB drives on Windows aren't visible as block devices in WSL.
+        # We need to attach them via usbipd or create a raw image first.
+        # Get the physical drive number from Windows.
+        result = subprocess.run(
+            ["powershell", "-Command",
+             f"Get-Partition -DriveLetter {letter.upper()} | "
+             f"Select-Object -ExpandProperty DiskNumber"],
+            capture_output=True, text=True
+        )
+        if result.returncode == 0 and result.stdout.strip().isdigit():
+            disk_num = result.stdout.strip()
+            phys_drive = f"\\\\.\\PhysicalDrive{disk_num}"
+            print(f"Detected {source} as {phys_drive} (disk {disk_num})")
+            print()
+            print("WSL cannot directly access USB block devices.")
+            print("Options:")
+            print("  1. Create a raw image first:")
+            print(f"     python recover.py --image {source} drive_image.img")
+            print("     python recover.py drive_image.img ./recovered --profile all")
+            print("  2. Attach the USB drive to WSL (requires usbipd):")
+            print("     usbipd list")
+            print("     usbipd bind --busid <BUSID>")
+            print("     usbipd attach --wsl --busid <BUSID>")
+            print("     Then use /dev/sdX directly")
+            print("  3. Boot a Linux live USB and run photorec natively")
+            sys.exit(1)
+
+        print(f"Warning: Could not auto-detect device for {source}")
+        print("Try specifying the device directly (e.g., /dev/sdb1)")
+        sys.exit(1)
+
+    return source
+
+
+def run_photorec(photorec_cmd, source, output_dir, profile_name, extensions, dry_run=False):
+    """Run photorec with the given parameters."""
+    output_path = Path(output_dir).resolve()
+    output_path.mkdir(parents=True, exist_ok=True)
+
+    # For WSL, convert Windows output path to /mnt/x/... format
+    if photorec_cmd[0] == "wsl":
+        win_path = str(output_path)
+        if win_path[1] == ":":
+            wsl_path = f"/mnt/{win_path[0].lower()}/{win_path[2:].replace(chr(92), '/')}"
+        else:
+            wsl_path = win_path.replace("\\", "/")
+        photorec_output = wsl_path
+    else:
+        photorec_output = str(output_path)
+
+    if profile_name == "full":
+        enable_line = "everything,enable"
+    else:
+        families = set()
+        for ext in extensions:
+            if ext in PHOTOREC_FAMILIES:
+                families.add(PHOTOREC_FAMILIES[ext])
+        enable_line = ",".join(sorted(families)) + ",enable"
+
+    print(f"{'[DRY RUN] ' if dry_run else ''}Recovery scan")
+    print(f"  Source:    {source}")
+    print(f"  Output:    {output_path}")
+    print(f"  Profile:   {profile_name}")
+    if profile_name != "full":
+        print(f"  File types: {enable_line}")
+    print()
+
+    if dry_run:
+        print("Dry run — no scan performed.")
+        print(f"Would run photorec on {source}")
+        print(f"Output would go to {output_path}")
+        return 0
+
+    # Check for admin privileges if accessing physical drives
+    if source.startswith("\\\\.\\Physical") and not is_admin():
+        elevate_and_rerun()
+        sys.exit(0)
+
+    # Build photorec command
+    # photorec /d <output> /cmd <source> fileopt,everything,disable,<families>,enable,search
+    if profile_name == "full":
+        cmd_str = "fileopt,everything,enable,search"
+    else:
+        cmd_str = f"fileopt,everything,disable,{enable_line},search"
+
+    cmd = photorec_cmd + [
+        "/d", photorec_output + "/",
+        "/cmd", source,
+        cmd_str,
+    ]
+
+    print(f"Running: {' '.join(cmd)}")
+    print("This may take a while...\n")
+
+    result = subprocess.run(cmd)
+    return result.returncode
+
+
+def organize_output(output_dir):
+    """Organize photorec output by file type."""
+    output_path = Path(output_dir)
+    if not output_path.exists():
+        return
+
+    # photorec creates recup_dir.1, recup_dir.2, etc.
+    moved = 0
+    for recup_dir in output_path.glob("recup_dir.*"):
+        for f in recup_dir.iterdir():
+            if f.is_file():
+                ext = f.suffix.lower().lstrip(".")
+                if not ext:
+                    ext = "unknown"
+                dest_dir = output_path / ext
+                dest_dir.mkdir(exist_ok=True)
+                dest = dest_dir / f.name
+                f.rename(dest)
+                moved += 1
+        # Remove empty recup_dir
+        try:
+            recup_dir.rmdir()
+        except OSError:
+            pass
+
+    if moved:
+        print(f"\nOrganized {moved} recovered files by extension.")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Recover files from a drive or disk image using photorec.",
+    )
+    parser.add_argument("source", nargs="?", help="Drive, partition, or disk image to scan")
+    parser.add_argument("output", nargs="?", help="Output directory for recovered files")
+    parser.add_argument("--profile", choices=list(PROFILES.keys()) + ["full"], default="all",
+                        help="File type profile to recover (default: all)")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Show what would be done without scanning")
+    parser.add_argument("--list-profiles", action="store_true",
+                        help="List available profiles and their file types")
+    parser.add_argument("--no-organize", action="store_true",
+                        help="Don't reorganize output by file type")
+    parser.add_argument("--json", action="store_true",
+                        help="Output summary as JSON")
+    parser.add_argument("--image", metavar="OUTPUT_IMG",
+                        help="Create a raw disk image instead of recovering files. "
+                             "Source must be a drive letter or device. "
+                             "Example: --image drive.img F:")
+    args = parser.parse_args()
+
+    if args.list_profiles:
+        for name, exts in PROFILES.items():
+            print(f"{name}:")
+            print(f"  {', '.join(sorted(exts))}")
+            print()
+        return
+
+    if args.image:
+        if not args.source:
+            parser.error("source is required with --image")
+        # --image OUTPUT_IMG SOURCE — source is the drive, image is the output file
+        create_disk_image(args.source, args.image, args.dry_run)
+        return
+
+    if not args.source or not args.output:
+        parser.error("source and output are required (use --list-profiles to see options)")
+
+    # Determine if source is a Windows drive letter — prefer native photorec
+    is_windows_drive = (len(args.source) <= 3 and args.source[0].isalpha()
+                        and args.source.endswith(":"))
+
+    # Find photorec
+    photorec_cmd, photorec_mode = find_photorec(prefer_native=is_windows_drive)
+    if not photorec_cmd:
+        print("Error: photorec not found.")
+        print("Install with:")
+        print("  Ubuntu/Debian: sudo apt install testdisk")
+        print("  macOS: brew install testdisk")
+        print("  Windows: download from https://www.cgsecurity.org/wiki/TestDisk_Download")
+        print("           extract to ~/tools/testdisk/")
+        print("  Windows WSL: wsl sudo apt install testdisk")
+        sys.exit(2)
+
+    # For Windows drives, use native photorec with \\.\PhysicalDriveN
+    if is_windows_drive and photorec_mode == "native":
+        letter = args.source[0].upper()
+        result = subprocess.run(
+            ["powershell", "-Command",
+             f"Get-Partition -DriveLetter {letter} | "
+             f"Select-Object -ExpandProperty DiskNumber"],
+            capture_output=True, text=True
+        )
+        if result.returncode == 0 and result.stdout.strip().isdigit():
+            disk_num = result.stdout.strip()
+            source = f"\\\\.\\PhysicalDrive{disk_num}"
+            print(f"Using native Windows photorec on {source}")
+        else:
+            print(f"Error: Could not find physical drive for {args.source}")
+            sys.exit(1)
+    else:
+        source = resolve_source(args.source)
+
+    extensions = PROFILES.get(args.profile, [])
+
+    start = datetime.now()
+
+    rc = run_photorec(
+        photorec_cmd, source, args.output,
+        args.profile, extensions, args.dry_run
+    )
+
+    elapsed = (datetime.now() - start).total_seconds()
+
+    if rc == 0 and not args.dry_run and not args.no_organize:
+        organize_output(args.output)
+
+    # Summary
+    if not args.dry_run:
+        output_path = Path(args.output)
+        file_count = sum(1 for _ in output_path.rglob("*") if _.is_file())
+        total_size = sum(f.stat().st_size for f in output_path.rglob("*") if f.is_file())
+
+        summary = {
+            "source": args.source,
+            "output": str(output_path),
+            "profile": args.profile,
+            "files_recovered": file_count,
+            "total_size_bytes": total_size,
+            "total_size_mb": round(total_size / (1024 * 1024), 1),
+            "elapsed_seconds": round(elapsed, 1),
+            "exit_code": rc,
+            "timestamp": datetime.now().isoformat(),
+        }
+
+        if args.json:
+            print(json.dumps(summary, indent=2))
+        else:
+            print("\nRecovery complete:")
+            print(f"  Files recovered: {file_count}")
+            print(f"  Total size:      {summary['total_size_mb']} MB")
+            print(f"  Elapsed:         {summary['elapsed_seconds']}s")
+            print(f"  Output:          {output_path}")
+
+        # Write summary to output dir
+        summary_path = output_path / "recovery_summary.json"
+        with open(summary_path, "w") as f:
+            json.dump(summary, f, indent=2)
+
+    sys.exit(rc)
+
+
+if __name__ == "__main__":
+    main()

--- a/scan-image.py
+++ b/scan-image.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python
+"""
+JP_TOOLS/scan-image.py
+Scan a raw disk image or device for embedded files and signatures.
+
+Uses binwalk for firmware/embedded file detection and custom scanners
+for file types that standard tools miss (ROM files, etc.).
+
+Usage:
+    python scan-image.py <image-or-device> [--output <dir>] [--extract] [--signatures <type>]
+
+Signature types:
+    default     — binwalk's built-in signatures (archives, images, firmware, etc.)
+    roms        — scan for retro ROM magic bytes (NES, SNES, GB, N64, Genesis, etc.)
+    all         — both default and ROM signatures
+
+Examples:
+    python scan-image.py disk.img --signatures all
+    python scan-image.py disk.img --extract --output ./extracted
+    python scan-image.py disk.img --signatures roms --output ./roms
+"""
+
+import sys
+import shutil
+import subprocess
+import argparse
+import json
+from pathlib import Path
+from datetime import datetime
+
+
+# ROM magic byte signatures
+# Format: (name, offset_from_start, magic_bytes, expected_size_range)
+ROM_SIGNATURES = [
+    ("NES", 0, b"NES\x1a", (16*1024, 4*1024*1024)),
+    ("SNES (SMC header)", 0x200, b"\x00" * 2, None),  # Too generic alone, needs validation
+    ("Game Boy", 0x104, b"\xce\xed\x66\x66\xcc\x0d\x00\x0b", (32*1024, 8*1024*1024)),
+    ("Game Boy Advance", 0x04, b"\x24\xff\xae\x51\x69\x9a\xa2\x21", (256*1024, 32*1024*1024)),
+    ("N64 (big-endian)", 0, b"\x80\x37\x12\x40", (1*1024*1024, 64*1024*1024)),
+    ("N64 (little-endian)", 0, b"\x40\x12\x37\x80", (1*1024*1024, 64*1024*1024)),
+    ("N64 (byte-swapped)", 0, b"\x37\x80\x40\x12", (1*1024*1024, 64*1024*1024)),
+    ("Sega Genesis", 0x100, b"SEGA", (128*1024, 8*1024*1024)),
+    ("Sega Master System", 0x7FF0, b"TMR SEGA", (32*1024, 1*1024*1024)),
+    ("NDS", 0, None, None),  # NDS has a complex header, skip for now
+    ("Atari 2600", 0, None, None),  # No reliable magic, skip
+    ("ISO 9660", 0x8001, b"CD001", (1*1024*1024, 8*1024*1024*1024)),
+    ("CHD (MAME)", 0, b"MComprHD", (1*1024*1024, 8*1024*1024*1024)),
+    ("CSO (compressed ISO)", 0, b"CISO", (1*1024*1024, 4*1024*1024*1024)),
+    ("GDI (Dreamcast)", 0, None, None),  # Text file, no reliable magic
+    ("CUE sheet", 0, b"FILE ", (50, 10*1024)),
+    ("PBP (PSP)", 0, b"\x00PBP\x00", (1*1024*1024, 2*1024*1024*1024)),
+    ("WBFS (Wii)", 0, b"WBFS", (1*1024*1024*1024, 8*1024*1024*1024)),
+    ("NKit (Wii/GC)", 0, b"NKIT", (1*1024*1024*1024, 8*1024*1024*1024)),
+    ("GCM (GameCube)", 0x1C, b"\xC2\x33\x9F\x3D", (1*1024*1024*1024, 2*1024*1024*1024)),
+    ("3DS", 0x100, b"NCSD", (256*1024*1024, 8*1024*1024*1024)),
+    ("NDS", 0xC0, b"\x24\xFF\xDE\x01", (1*1024*1024, 512*1024*1024)),
+    ("Atari 7800", 1, b"ATARI7800", (8*1024, 512*1024)),
+    ("Atari Lynx", 0, b"LYNX", (64*1024, 512*1024)),
+    ("TurboGrafx/PCE", 0, None, None),  # No reliable magic
+    ("Neo Geo", 0x100, b"NEO-GEO", (256*1024, 64*1024*1024)),
+    ("FDS (Famicom Disk)", 0, b"FDS\x1a", (65500, 2*65500)),
+    ("Intellivision", 0, None, None),  # No reliable magic
+    ("Sega 32X", 0x100, b"SEGA 32X", (512*1024, 4*1024*1024)),
+    ("Sega CD", 0, b"SEGADISCSYSTEM", (1*1024*1024, 700*1024*1024)),
+    ("WordPerfect", 0, b"\xFF\x57\x50\x43", (1*1024, 50*1024*1024)),
+]
+
+# Only include signatures with actual magic bytes
+ROM_SIGNATURES = [(name, off, magic, size)
+                  for name, off, magic, size in ROM_SIGNATURES
+                  if magic is not None and len(magic) >= 4]
+
+
+def find_binwalk():
+    """Find binwalk binary."""
+    path = shutil.which("binwalk")
+    if path:
+        return [path]
+
+    result = subprocess.run(
+        ["wsl", "which", "binwalk"],
+        capture_output=True, text=True
+    )
+    if result.returncode == 0 and result.stdout.strip():
+        return ["wsl", result.stdout.strip()]
+
+    return None
+
+
+def win_to_wsl_path(win_path):
+    p = str(win_path)
+    if len(p) >= 2 and p[1] == ":":
+        return f"/mnt/{p[0].lower()}/{p[2:].replace(chr(92), '/')}"
+    return p.replace("\\", "/")
+
+
+def run_binwalk(source, output_dir=None, extract=False):
+    """Run binwalk signature scan."""
+    binwalk = find_binwalk()
+    if not binwalk:
+        print("Warning: binwalk not found — skipping standard signature scan")
+        return []
+
+    if binwalk[0] == "wsl":
+        src = win_to_wsl_path(source) if ":" in str(source) else str(source)
+        cmd = ["wsl", "binwalk"]
+    else:
+        src = str(source)
+        cmd = binwalk[:]
+
+    if extract and output_dir:
+        out = win_to_wsl_path(output_dir) if ":" in str(output_dir) else str(output_dir)
+        cmd.extend(["--extract", "--directory", out])
+
+    cmd.append(src)
+
+    print(f"Running binwalk: {' '.join(cmd)}")
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    print(result.stdout)
+    if result.stderr:
+        print(result.stderr, file=sys.stderr)
+
+    return result.stdout
+
+
+def scan_for_roms(source, output_dir=None, chunk_size=64*1024*1024):
+    """Scan a raw image for ROM file signatures."""
+    source_path = Path(source)
+    if not source_path.exists():
+        print(f"Error: {source} not found")
+        return []
+
+    file_size = source_path.stat().st_size
+    found = []
+
+    print(f"Scanning {source} ({round(file_size / (1024**3), 1)} GB) for ROM signatures...")
+    print(f"Signatures: {', '.join(name for name, _, _, _ in ROM_SIGNATURES)}")
+    print()
+
+    # Build a search plan: for each signature, what bytes to look for
+    # We scan in chunks and look for magic bytes
+    with open(source, "rb") as f:
+        offset = 0
+        chunk_num = 0
+        while offset < file_size:
+            chunk = f.read(chunk_size)
+            if not chunk:
+                break
+
+            for sig_name, sig_offset, magic, size_range in ROM_SIGNATURES:
+                # Search for magic bytes in this chunk
+                search_start = 0
+                while True:
+                    pos = chunk.find(magic, search_start)
+                    if pos == -1:
+                        break
+
+                    # The magic is at chunk position `pos`, but the file would
+                    # start at `pos - sig_offset` (since the magic is at sig_offset
+                    # within the file)
+                    file_start = offset + pos - sig_offset
+                    if file_start < 0:
+                        search_start = pos + 1
+                        continue
+
+                    hit = {
+                        "type": sig_name,
+                        "offset": file_start,
+                        "magic_at": offset + pos,
+                        "hex_offset": f"0x{file_start:X}",
+                    }
+                    found.append(hit)
+
+                    if len(found) % 100 == 0:
+                        print(f"  Found {len(found)} signatures so far... "
+                              f"({round(offset / file_size * 100, 1)}%)")
+
+                    search_start = pos + 1
+
+            new_offset = offset + len(chunk) - 256  # Overlap to catch signatures at boundaries
+            if new_offset <= offset:
+                break  # Prevent infinite loop at end of file
+            offset = new_offset
+            f.seek(offset)
+            chunk_num += 1
+
+            # Progress every 1GB
+            if chunk_num % 16 == 0:
+                pct = round(offset / file_size * 100, 1)
+                print(f"  {pct}% scanned, {len(found)} signatures found...")
+
+    print(f"\nScan complete: {len(found)} signatures found")
+
+    # Summary by type
+    from collections import Counter
+    counts = Counter(h["type"] for h in found)
+    for sig_type, count in counts.most_common():
+        print(f"  {sig_type}: {count}")
+
+    # Save results
+    if output_dir:
+        out_path = Path(output_dir)
+        out_path.mkdir(parents=True, exist_ok=True)
+        results_file = out_path / "rom_scan_results.json"
+        with open(results_file, "w") as f:
+            json.dump({
+                "source": str(source),
+                "signatures_found": len(found),
+                "results": found[:10000],  # Cap at 10k to avoid huge files
+                "summary": dict(counts),
+                "timestamp": datetime.now().isoformat(),
+            }, f, indent=2)
+        print(f"\nResults saved to {results_file}")
+
+    return found
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Scan disk images for embedded files and ROM signatures.",
+    )
+    parser.add_argument("source", help="Disk image or device to scan")
+    parser.add_argument("--output", "-o", help="Output directory for results/extracted files")
+    parser.add_argument("--extract", action="store_true",
+                        help="Extract found files (binwalk only)")
+    parser.add_argument("--signatures", choices=["default", "roms", "all"],
+                        default="default",
+                        help="Which signatures to scan for (default: default)")
+    args = parser.parse_args()
+
+    start = datetime.now()
+
+    if args.signatures in ("default", "all"):
+        print("=== Standard signature scan (binwalk) ===\n")
+        run_binwalk(args.source, args.output, args.extract)
+
+    if args.signatures in ("roms", "all"):
+        print("\n=== ROM signature scan ===\n")
+        scan_for_roms(args.source, args.output)
+
+    elapsed = (datetime.now() - start).total_seconds()
+    print(f"\nTotal elapsed: {round(elapsed, 1)}s")
+
+
+if __name__ == "__main__":
+    main()

--- a/undelete.py
+++ b/undelete.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python
+"""
+JP_TOOLS/undelete.py
+Recover deleted files from NTFS or ext3/ext4 filesystems.
+
+Unlike photorec (which carves raw data by signature), this tool uses
+filesystem metadata to find recently deleted files with their original
+names and directory structure intact. Works best on recently deleted files
+before the space has been overwritten.
+
+Usage:
+    python undelete.py <device-or-image> <output-dir> [--type ntfs|ext] [--list-only] [--match <pattern>]
+
+Examples:
+    python undelete.py /dev/sdb1 ./recovered --type ntfs
+    python undelete.py /dev/sdb1 ./recovered --type ntfs --match "*.js"
+    python undelete.py disk.img ./recovered --type ext
+    python undelete.py /dev/sdb1 ./recovered --list-only
+"""
+
+import sys
+import shutil
+import subprocess
+import argparse
+from pathlib import Path
+from datetime import datetime
+
+
+def find_tool(name):
+    """Find a tool, checking local installs, PATH, then WSL."""
+    # Check native Windows tool locations
+    if sys.platform == 'win32':
+        win_paths = [
+            Path.home() / "tools" / "sleuthkit" / "sleuthkit-4.14.0-win32" / "bin" / f"{name}.exe",
+            Path.home() / "tools" / "sleuthkit" / "bin" / f"{name}.exe",
+        ]
+        for p in win_paths:
+            if p.exists():
+                return [str(p)]
+
+    # Check PATH
+    path = shutil.which(name)
+    if path:
+        return [path]
+
+    # Try WSL only on Windows
+    if sys.platform == 'win32':
+        try:
+            result = subprocess.run(
+                ["wsl", "which", name],
+                capture_output=True, text=True
+            )
+            if result.returncode == 0 and result.stdout.strip():
+                return ["wsl", result.stdout.strip()]
+        except FileNotFoundError:
+            pass
+
+    return None
+
+
+def win_to_wsl_path(win_path):
+    p = str(win_path)
+    if len(p) >= 2 and p[1] == ":":
+        return f"/mnt/{p[0].lower()}/{p[2:].replace(chr(92), '/')}"
+    return p.replace("\\", "/")
+
+
+def detect_fs_type(source):
+    """Try to detect filesystem type."""
+    cmd = find_tool("blkid")
+    if not cmd:
+        return None
+
+    if cmd[0] == "wsl":
+        cmd = ["wsl", "sudo", "blkid", source]
+    else:
+        cmd = cmd + [source]
+
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    output = result.stdout.lower()
+
+    if "ntfs" in output:
+        return "ntfs"
+    elif "ext4" in output or "ext3" in output:
+        return "ext"
+    return None
+
+
+def list_deleted_ntfs(source, match=None):
+    """List deleted files on NTFS using ntfsundelete."""
+    tool = find_tool("ntfsundelete")
+    if not tool:
+        print("Error: ntfsundelete not found. Install ntfs-3g.")
+        sys.exit(2)
+
+    cmd = tool[:]
+    if tool[0] == "wsl":
+        cmd = ["wsl", "sudo", "ntfsundelete", source, "--scan"]
+    else:
+        cmd = tool + [source, "--scan"]
+
+    if match:
+        cmd.extend(["--match", match])
+
+    print(f"Scanning for deleted files on {source}...")
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    print(result.stdout)
+    if result.stderr:
+        print(result.stderr, file=sys.stderr)
+    return result.returncode
+
+
+def recover_ntfs(source, output_dir, match=None):
+    """Recover deleted files from NTFS using ntfsundelete."""
+    tool = find_tool("ntfsundelete")
+    if not tool:
+        print("Error: ntfsundelete not found. Install ntfs-3g.")
+        sys.exit(2)
+
+    output_path = Path(output_dir).resolve()
+    output_path.mkdir(parents=True, exist_ok=True)
+
+    if tool[0] == "wsl":
+        wsl_output = win_to_wsl_path(output_path)
+        cmd = ["wsl", "sudo", "ntfsundelete", source,
+               "--undelete", "--destination", wsl_output]
+    else:
+        cmd = tool + [source, "--undelete",
+                      "--destination", str(output_path)]
+
+    if match:
+        cmd.extend(["--match", match])
+    else:
+        cmd.extend(["--match", "*"])
+
+    print(f"Recovering deleted files from {source}...")
+    print(f"Output: {output_path}")
+    print(f"Running: {' '.join(cmd)}")
+    result = subprocess.run(cmd)
+    return result.returncode
+
+
+def list_deleted_ext(source, match=None):
+    """List deleted files on ext3/ext4 using sleuthkit fls."""
+    tool = find_tool("fls")
+    if not tool:
+        print("Error: fls not found. Install sleuthkit.")
+        sys.exit(2)
+
+    if tool[0] == "wsl":
+        cmd = ["wsl", "sudo", "fls", "-r", "-d", source]
+    else:
+        cmd = tool + ["-r", "-d", source]
+
+    print(f"Scanning for deleted files on {source}...")
+    result = subprocess.run(cmd, capture_output=True, text=True)
+
+    lines = result.stdout.strip().split("\n") if result.stdout.strip() else []
+
+    if match:
+        import fnmatch
+        lines = [entry for entry in lines if fnmatch.fnmatch(entry.lower(), f"*{match.lower()}*")]
+
+    for line in lines[:100]:
+        print(line)
+
+    if len(lines) > 100:
+        print(f"... and {len(lines) - 100} more")
+
+    print(f"\nTotal deleted entries found: {len(lines)}")
+    return result.returncode
+
+
+def recover_ext(source, output_dir, match=None):
+    """Recover deleted files from ext3/ext4 using extundelete."""
+    tool = find_tool("extundelete")
+    if not tool:
+        print("Error: extundelete not found. Install extundelete.")
+        sys.exit(2)
+
+    output_path = Path(output_dir).resolve()
+    output_path.mkdir(parents=True, exist_ok=True)
+
+    if tool[0] == "wsl":
+        wsl_output = win_to_wsl_path(output_path)
+        cmd = ["wsl", "sudo", "extundelete", source,
+               "--restore-all", "--output-dir", wsl_output]
+    else:
+        cmd = tool + [source, "--restore-all",
+                      "--output-dir", str(output_path)]
+
+    print(f"Recovering deleted files from {source}...")
+    print(f"Output: {output_path}")
+    print(f"Running: {' '.join(cmd)}")
+    result = subprocess.run(cmd)
+    return result.returncode
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Recover deleted files from NTFS or ext3/ext4 filesystems.",
+    )
+    parser.add_argument("source", help="Device or disk image to scan")
+    parser.add_argument("output", nargs="?", help="Output directory for recovered files")
+    parser.add_argument("--type", choices=["ntfs", "ext"],
+                        help="Filesystem type (auto-detected if not specified)")
+    parser.add_argument("--list-only", action="store_true",
+                        help="List deleted files without recovering them")
+    parser.add_argument("--match", metavar="PATTERN",
+                        help="Filename pattern to match (e.g., '*.js', '*.psd')")
+    args = parser.parse_args()
+
+    if not args.list_only and not args.output:
+        parser.error("output directory is required unless using --list-only")
+
+    # Detect filesystem type
+    fs_type = args.type
+    if not fs_type:
+        fs_type = detect_fs_type(args.source)
+        if not fs_type:
+            print("Could not auto-detect filesystem type. Use --type ntfs or --type ext")
+            sys.exit(1)
+        print(f"Detected filesystem: {fs_type}")
+
+    start = datetime.now()
+
+    if args.list_only:
+        if fs_type == "ntfs":
+            rc = list_deleted_ntfs(args.source, args.match)
+        else:
+            rc = list_deleted_ext(args.source, args.match)
+    else:
+        if fs_type == "ntfs":
+            rc = recover_ntfs(args.source, args.output, args.match)
+        else:
+            rc = recover_ext(args.source, args.output, args.match)
+
+    elapsed = (datetime.now() - start).total_seconds()
+    print(f"\nElapsed: {round(elapsed, 1)}s")
+    sys.exit(rc)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- CHD archive management (`chd.py`, `chd-hunkmap.py`) — create, verify, extract, batch convert, hunk-level dedup analysis
- File recovery (`recover.py`, `undelete.py`) — photorec profiles, sleuthkit NTFS/ext recovery
- Disk imaging (`image-disk.py`) — forensic imaging via ddrescue
- Image scanning (`scan-image.py`) — ROM signature and embedded file detection
- Automated installers for Linux/WSL (`install-recovery.sh`) and Windows (`install-recovery.ps1`)
- Windows improvements: native chdman path detection, MAME auto-install from GitHub releases
- Updated README with full tool inventory

## Context
These were developed on the `recovery-tools` branch. This PR extracts just the recovery tools (no FileScanner — that's moving to iteration8/utilities in #6).

## Test plan
- [ ] `python chd.py --help` runs without error
- [ ] `python recover.py --help` runs without error
- [ ] `python scan-image.py --help` runs without error
- [ ] Windows: `find_chdman()` checks native paths before PATH/WSL

🤖 Generated with [Claude Code](https://claude.com/claude-code)