### PR TITLE
Add three tools for recovering from a drive that will not mount

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,17 @@ That edits your local `composer.json` — don't commit those two entries back.
 | `undelete.py` | Recover deleted files from NTFS/ext filesystems |
 | `image-disk.py` | Forensic disk imaging via ddrescue |
 | `scan-image.py` | Scan raw images for ROM signatures and embedded files |
+| `ntfs-inventory.py` | List an **unmountable** NTFS volume to TSV — resumable, metadata only |
+| `ntfs-size.py` | Size a subtree on an unmountable volume, before committing to a copy |
+| `ntfs-extract.py` | Copy a tree off an unmountable volume — resumable, skips unreadable files |
+| `inventory-drive.py` | Catalogue a **mounted** volume to the same TSV format, for offline diffing |
+
+The last four cover a gap between imaging and carving: **the volume will not
+mount, but the live files are intact.** `image-disk.py` needs somewhere to put a
+full image, and `undelete.py` looks for deleted files — neither helps when the
+files are fine and only the filesystem metadata is damaged. Inventory first,
+size what you might want, then copy. Comparing that inventory against drives you
+already own is usually what shrinks the job most.
 
 ### Archive Management (Python)
 

--- a/docs/data-recovery-notes.md
+++ b/docs/data-recovery-notes.md
@@ -59,10 +59,11 @@ expensive ones.
 
 **Verify — before trusting or deleting**
 
-- [ ] Compare counts and sizes against the source listing
+- [ ] Compare **bytes** against the source listing; counts alone mislead (below)
 - [ ] Check the error log; know exactly what was lost
 - [ ] Hash-verify anything whose original you intend to delete
 - [ ] Confirm a **second copy exists on different hardware**
+- [ ] Verify a rescue someone else did, too — a partial one looks complete
 
 **Only then**
 
@@ -203,6 +204,109 @@ Two thirds of the planned copy was unnecessary. Size-matching is strong evidence
 rather than proof; hash before *deleting* anything, but it is more than enough
 to decide what to rescue first.
 
+### Size matching has a precondition: the same format on both sides
+
+The advice above holds only while both collections store the content the same
+way. It fails completely otherwise, and the failure is silent — every title
+reads as unique.
+
+A later pass compared a LaunchBox library of raw `.iso` against the same games
+held as `.chd` elsewhere. **CHD is compressed, so no size will ever agree**, and
+there was no disc ID in the filenames to fall back on. Names were all that was
+left, and names across ROM collections need real normalisation:
+
+- region and language tags — `(Europe) (En,Fr,De,Es,It)`, `[SLUS_21613]`
+- TOSEC version tokens — `Crazy Taxi v1.005 (2000)(Sega)(US)[!]`
+- the `", The"` suffix convention — `Sopranos, The - Road to Respect` against
+  `Sopranos - Road to Respect`
+- disc numbers, which must **survive** normalisation, or the discs of a
+  multi-disc game collapse into one entry
+
+Each of those, left unhandled, produced a plausible number pointing the wrong
+way. The version token alone made **every single** Dreamcast title fail to match
+against a set that contained most of them.
+
+Verdict: use sizes when formats agree, names when they do not, and **hashes when
+neither works** — one collection was named purely by number (`gba/0458.gba`),
+where no amount of normalisation can help.
+
+### Pick identity fields deliberately
+
+Where a stable identifier exists in the path, it beats both. Wii images carry
+Nintendo's six-character disc ID in the directory name (`Zoo Hospital [RZHE5G]`),
+which made a three-way comparison exact rather than probabilistic — and showed
+two of the three libraries were strict subsets of the third, removing 494 GB
+from the migration.
+
+Two counting traps came with it. **A `.wbfs` over 4 GB is split into `.wbf1`,
+`.wbf2`…** — continuations of one disc, so counting files counts them twice.
+And **trimmed formats legitimately differ in size between good copies**: one
+drive's images were smaller on 73 discs and larger on none, which is also what
+truncation looks like. What distinguished them was that every image on every
+drive was a whole number of 2 MiB wbfs blocks — an interrupted copy lands on an
+arbitrary offset, not a block boundary.
+
+---
+
+## Verifying a copy: compare bytes, not file counts
+
+Two failures here look identical from a distance, and they point opposite ways.
+
+**A complete copy can be short on file count.** Extractors commonly skip
+zero-byte files — `ntfs-extract.py` does, via its minimum-size filter. Three
+directories came back short by exactly **1, 10 and 7 files** while the byte
+totals matched to the byte. That reads as data loss and is not:
+
+    Pictures            582 files   7,099,491,553 B   exact
+    Desktop              55 of 56   561,130,277 B     exact  <- 1 zero-byte file
+    projects          1,395 of 1,405  141,239,822 B   exact  <- 10 zero-byte files
+    Batocera.PLUS-bios  595 of 602   394,374,931 B    exact  <- 7 zero-byte files
+
+Count the zero-byte entries in the source listing before concluding anything.
+If they account for the gap and the bytes match, the copy is complete.
+
+**An incomplete copy can look finished.** A rescue done in an earlier session
+had put three trees on a server. Two were byte-exact. The third was not:
+
+    music   9,427 files  31,228,325,650 B  ->  9,686 files  31,228,327,574 B  complete
+    porn      139 files   6,362,374,325 B  ->    173 files   6,362,378,413 B  complete
+    mame   37,403 files  66,721,041,858 B  -> 35,102 files  66,086,878,805 B  634 MB SHORT
+
+From a directory listing all three look done. Only the byte comparison shows
+2,301 files and 634 MB missing from the third. **A partial rescue is the most
+dangerous kind, because it reads as complete** — and the destination having
+*more* files than the source (zero-byte entries again) makes a naive count
+comparison actively misleading in both directions.
+
+---
+
+## Throughput: it is usually the destination
+
+The instinct on a slow rescue is to blame the failing drive, and then to move it
+to a different machine. Measure the link speeds first — `lsusb -t`, and the
+`speed` file in the device's sysfs path:
+
+    failing drive   /dev/sdb   usb2/2-1   5000 Mbps    <- full USB 3.0
+    destination     /dev/sdc   usb1/1-2    480 Mbps    <- USB 2.0, ~33 MB/s
+    over wifi       5 GHz                              <- 12 MB/s measured
+
+The dying drive was never the constraint. And note the destination at USB 2.0 is
+still **2.75x faster than the network**, so "stage it to the fast server
+instead" would have made the rescue slower, not faster. Keep rescue targets on
+local USB; move data machine-to-machine afterwards.
+
+A USB 3.0 drive negotiating at 480 Mbps is usually the **cable**. WD My Passport
+and similar use a USB 3.0 Micro-B socket, and an ordinary USB 2.0 micro cable
+fits the left half of it and works — at USB 2.0 speed, with nothing to suggest
+anything is wrong.
+
+**Do not relocate the failing drive to another machine** unless you have
+measured that it is the bottleneck. It costs a power cycle, and a marginal drive
+failing to spin back up is a normal way for these to end. It also usually costs
+you your tooling: an unmountable NTFS volume is readable from Linux via
+`ntfsls`/`ntfscat` and not much else, so moving it to a Windows box trades a
+working rescue for a dead end.
+
 ---
 
 ## Things that produced confident wrong answers
@@ -241,5 +345,12 @@ Each of these looked like a result:
   on PATH" are different claims.
 - **FAT32 caps a single file at 4 GB**, so it cannot hold a disk image of
   anything meaningful — fine for many small files, useless for one big one.
+  The cap also leaves a **signature worth recognising in old data**: a file of
+  exactly **4,294,967,295 bytes** (2^32-1) was truncated when it crossed a FAT32
+  volume at some point in its history. Five DVD images on one drive shared that
+  byte count exactly, and they were the only titles that appeared unique in a
+  library comparison — so they read as "the last five things worth rescuing"
+  when in fact they were the five things already broken. Sort candidates by size
+  and look for repeated identical values near a power of two.
 - **Filesystems flagged dirty after a link drop** may have no real damage. A
   read-only check distinguishes the two; a repair pass assumes the answer.

--- a/docs/data-recovery-notes.md
+++ b/docs/data-recovery-notes.md
@@ -1,0 +1,245 @@
+# Field notes: recovering from failing drives
+
+Written after an evening spent on four drives at once, three of them with
+something wrong. Every number here is measured, not remembered. The tools in
+this repo do the work; this is the judgement that decides *which* work.
+
+The single most useful habit: **a check that has not itself been checked is a
+confident source of wrong answers.** Most of the mistakes below produced
+plausible output that happened to be false.
+
+---
+
+## Order of operations
+
+1. **Inventory** — names and sizes only. Costs directory seeks, not transfer.
+2. **Size** what you might want (`ntfs-size.py`). Decide *before* committing.
+3. **Compare** against what you already have. This is where the big wins are.
+4. **Copy**, highest value first, one pass.
+5. **Repair** — and only ever the copy.
+
+Steps 1–3 are nearly free and routinely change the answer to step 4. On this
+job they cut a planned 1.1 TB rescue down to 393 GB, because comparing
+inventories showed the Wii and PS1 collections already existed elsewhere.
+
+**Never repair before copying.** `fsck`, `ntfsfix`, `chkdsk` all *write*, and
+writing to a disk with pending sectors is how a recoverable situation becomes an
+unrecoverable one. A read-only check (`fsck.vfat -n`) is fine and tells you
+whether the damage is real or just a dirty flag.
+
+---
+
+## Checklist
+
+Work through it in order; the cheap steps keep changing the answer to the
+expensive ones.
+
+**Assess — before touching anything**
+
+- [ ] `smartctl -d sat -a` on every drive involved (`-d sat` for USB bridges)
+- [ ] Read `Reported_Uncorrect` and `Current_Pending_Sector`, not `PASSED`
+- [ ] Check `worst` vs `value` — a moving count means active damage
+- [ ] Decide: platter failure, or bridge/cable? (`Medium Error` vs `DID_NO_CONNECT`)
+- [ ] Is the enclosure shuckable? Hardware-encrypting bridges are not
+
+**Catalogue — costs seeks, not transfer**
+
+- [ ] `inventory-drive.py` if it mounts; `ntfs-inventory` style listing if not
+- [ ] `ntfs-size.py` on anything you might want, before deciding to take it
+- [ ] Inventory the destinations too, and diff — most of a rescue is often redundant
+- [ ] Identify what exists in exactly **one** place; that is the real payload
+
+**Copy — one pass, highest value first**
+
+- [ ] Somewhere with room, checked in advance
+- [ ] Source mounted **read-only**, or read via `ntfsls`/`ntfscat`
+- [ ] Errors logged and skipped, never fatal
+- [ ] Irreplaceable before large: order by "can I ever get this again"
+- [ ] Monitor for a stall, and distinguish "finished" from "died"
+
+**Verify — before trusting or deleting**
+
+- [ ] Compare counts and sizes against the source listing
+- [ ] Check the error log; know exactly what was lost
+- [ ] Hash-verify anything whose original you intend to delete
+- [ ] Confirm a **second copy exists on different hardware**
+
+**Only then**
+
+- [ ] Read-only filesystem check (`fsck.vfat -n`, `ntfsfix -n`) to see if damage is real
+- [ ] Any repair runs against the copy, never the original
+- [ ] Record what failed and why, while it is still fresh
+
+---
+
+## Reading SMART properly
+
+**`PASSED` is close to meaningless.** It means no pre-fail attribute has crossed
+its own threshold. Attributes that matter most often have a threshold of 0, so
+they can never trigger it.
+
+The four drives, side by side — the failing one is not the one with the most
+reallocations:
+
+| | Seagate 2 TB | FreeAgent 1.5 TB | ThinkCentre 1 TB | WD Passport 2 TB |
+|---|---|---|---|---|
+| Reallocated_Sector_Ct | 204 | **397** | 0 | 0 |
+| Current_Pending_Sector | **84** | 0 | 0 | 0 |
+| Reported_Uncorrect | **3,751** | 0 | 0 | 0 |
+| Power_On_Hours | — | 29,712 | 11,716 | 10,354 |
+| verdict | **dying** | old, stable | fine | fine |
+
+- **`Reported_Uncorrect` is the number to look at.** It counts reads the drive
+  handed back as failures. 3,751 with a normalised value floored at 1/100 is a
+  drive actively losing data. 397 reallocations with *zero* uncorrectables is a
+  drive that had a bad patch, remapped it, and stabilised.
+- **`Current_Pending_Sector` is the leading indicator** — sectors it cannot read
+  *now* and has not yet remapped. Watch whether `worst` differs from `value`;
+  that means the count has been moving, so the damage is active.
+- **Reallocated alone says little.** It is history, not prognosis.
+
+### Raw values lie, per vendor
+
+**Seagate `Seek_Error_Rate` packs two fields into one number**: the top 16 bits
+are an error count, the bottom 32 a total. A raw value of 8,598,366,419 decodes
+to **2 errors in 8,431,827 seeks** — negligible, not eight billion failures.
+Hitachi's `Raw_Read_Error_Rate` of exactly 65536 (2^16) is the same class of
+artefact. Trust the **normalised** value against its threshold; treat raw values
+as vendor-specific until decoded.
+
+### Portable drives
+
+`Load_Cycle_Count` is the one that kills 2.5" USB drives — aggressive head
+parking against a ~600k rating. 36,403 is nothing; 500,000+ on a five-year-old
+drive is the real story even with zero bad sectors.
+
+---
+
+## Is it the disk, the bridge, or the cable?
+
+USB enclosures fail more often than the drives inside them, and the symptoms are
+completely different from platter failure.
+
+**Platter/medium failure** — the drive is present and answering, individual
+reads fail:
+
+```
+Sense Key : Medium Error [current]
+Add. Sense: Unrecovered read error
+critical medium error, dev sdb, sector 6811649
+```
+
+**Link/enclosure/cable failure** — the device disappears entirely:
+
+```
+usb 1-2: USB disconnect
+usb usb1-port2: Cannot enable. Maybe the USB cable is bad?
+usb usb1-port2: unable to enumerate USB device
+Synchronize Cache(10) failed: hostbyte=DID_NO_CONNECT
+```
+
+`DID_NO_CONNECT` means the device went away, not that a read failed. The kernel
+literally suggests the cable, and it is right often enough to check first. A
+drive that drops **under load** while reporting clean SMART is usually a
+marginal power supply or a tired bridge board, not a dying disk.
+
+Fix order: different port (direct, not through a hub) → different cable →
+reseat power → shuck and use SATA.
+
+**Except you cannot shuck everything.** WD My Passport and similar do AES **in
+the bridge chip**, always on, even with no password set. Pull the drive out and
+a SATA controller sees noise. If the bridge dies the data goes with it, so for
+those the cable is the *only* cheap fix and a second copy is the only real
+insurance.
+
+---
+
+## When NTFS will not mount
+
+Read the actual error. These are different problems:
+
+```
+Failed to read NTFS $MFT     -- the file table. Serious.
+Failed to read NTFS $Bitmap  -- the cluster allocation map.
+```
+
+**`$Bitmap` is only needed to allocate space.** ntfs-3g reads it at mount time
+regardless, but *nothing* needs it in order to read an existing file. So a
+volume can be completely unmountable and still fully readable by tools that
+parse the `$MFT` directly:
+
+- `ntfsls` — list a directory
+- `ntfscat` — extract one file
+- `testdisk` — interactive browse and copy
+
+That is the entire basis of `ntfs-extract.py`. On the drive above, mounting
+failed every time while **356 GB across 1,183 files** came off cleanly.
+
+`ro,norecover` is worth one attempt — it skips journal replay, which is what
+usually blocks a dirty volume — but it does not skip `$Bitmap`.
+
+---
+
+## Comparing drives without attaching both
+
+The highest-leverage step, and the cheapest. `inventory-drive.py` records
+path/size/mtime; two inventories then diff offline.
+
+**Match on size multisets, not filenames.** Names differ across collections for
+the same content; sizes rarely collide by accident for large media files. Beware
+that per-title subdirectories often use the same inner filename (`game.iso`),
+so key on the full path or on sizes — keying on basename collapses hundreds of
+titles into a handful and produces a confidently wrong comparison.
+
+Outcome on this job:
+
+| | on the failing drive | already elsewhere? |
+|---|---|---|
+| Wii, 592 GB | 279 images | **yes** — 209 size-identical on another drive |
+| PS1, 121 GB | 230 images | **yes** — 226 of 230 (98%) |
+| GameCube, 393 GB | 359 images | **no** — only 5 elsewhere |
+
+Two thirds of the planned copy was unnecessary. Size-matching is strong evidence
+rather than proof; hash before *deleting* anything, but it is more than enough
+to decide what to rescue first.
+
+---
+
+## Things that produced confident wrong answers
+
+Each of these looked like a result:
+
+- **`dmesg | wc -l` to detect new events.** The ring buffer was full, so new
+  messages pushed old ones out and the count never changed. Reported "no kernel
+  activity" while a drive attached successfully.
+- **A snap flooding the kernel log.** MongoDB's `ftdc` thread hit an apparmor
+  denial three times a second, so *any* device-attach message aged out of the
+  buffer within minutes. `dmesg` was useless on that machine until it was
+  disabled; `journalctl -k --since` was not.
+- **`pgrep -f "somethin[g]"` matching its own command line** when the same string
+  appeared in another argument of the same command. Write the pid to a file and
+  kill by pid.
+- **`ps comm` truncating at 15 characters** — grepping for a 16-character process
+  name finds nothing and the process looks dead while it is serving traffic.
+- **A tool that is not installed returns empty, which reads exactly like a clean
+  negative.** An `xwininfo` window count reported zero throughout — because
+  `xwininfo` was absent. The giveaway was that the *baseline* sample was also
+  zero when it certainly should not have been. Always include a case you know
+  should be non-empty.
+- **`Permission denied` and `I/O error` look identical** through a failed
+  command. Check which one you got before concluding the disk is unreadable.
+- **A shell glob missing case variants** — `*.v64` found 84 files where a
+  case-insensitive match found 88.
+
+---
+
+## Non-obvious environment traps
+
+- **A flatpak has its own `/tmp`.** Writing a report there leaves it invisible to
+  the host. Write to a path the sandbox explicitly shares.
+- **`which php` finds nothing when PHP is a flatpak.** "Not installed" and "not
+  on PATH" are different claims.
+- **FAT32 caps a single file at 4 GB**, so it cannot hold a disk image of
+  anything meaningful — fine for many small files, useless for one big one.
+- **Filesystems flagged dirty after a link drop** may have no real damage. A
+  read-only check distinguishes the two; a repair pass assumes the answer.

--- a/install-recovery.sh
+++ b/install-recovery.sh
@@ -23,7 +23,7 @@ if command -v apt &>/dev/null; then
 
     echo ""
     echo "--- Filesystem recovery ---"
-    sudo apt install -y ntfs-3g        # includes ntfsundelete
+    sudo apt install -y ntfs-3g        # ntfsundelete, and ntfsls/ntfscat for ntfs-extract.py
     sudo apt install -y extundelete 2>/dev/null || echo "    extundelete not available in this repo — skipping"
 
     echo ""

--- a/inventory-drive.py
+++ b/inventory-drive.py
@@ -34,7 +34,7 @@ import os
 import re
 import sys
 import time
-from typing import Set, TextIO
+from typing import TextIO
 
 WIN_DRIVE = re.compile(r"^([A-Za-z]):[\\/]?$")
 
@@ -50,9 +50,9 @@ def win_to_wsl_path(win_path: str) -> str:
     return win_path
 
 
-def already_recorded(path: str) -> Set[str]:
+def already_recorded(path: str) -> set[str]:
     """Top-level directories present in an existing inventory."""
-    tops: Set[str] = set()
+    tops: set[str] = set()
     if not os.path.exists(path):
         return tops
     with open(path, encoding="utf-8", errors="replace") as handle:
@@ -104,14 +104,14 @@ def main() -> int:
 
     root = win_to_wsl_path(args.mountpoint).rstrip("/")
     if not os.path.isdir(root):
-        print("not a directory: %s" % root, file=sys.stderr)
+        print(f"not a directory: {root}", file=sys.stderr)
         return 1
 
     if args.rescan and os.path.exists(args.output):
         os.unlink(args.output)
     done = already_recorded(args.output)
     if done:
-        print("resuming -- already recorded: %s" % ", ".join(sorted(done)))
+        print("resuming -- already recorded: {}".format(", ".join(sorted(done))))
 
     try:
         entries = sorted(
@@ -119,7 +119,7 @@ def main() -> int:
             if not e.startswith("$") and e != "System Volume Information"
         )
     except OSError as exc:
-        print("cannot read %s: %s" % (root, exc), file=sys.stderr)
+        print(f"cannot read {root}: {exc}", file=sys.stderr)
         return 1
     if args.subdirs:
         entries = [e for e in entries if e in args.subdirs]

--- a/inventory-drive.py
+++ b/inventory-drive.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python
+"""
+JP_TOOLS/inventory-drive.py
+Catalogue a mounted volume so it can be compared later, offline.
+
+Answers "do I already have this?" about a drive that is sitting in a drawer.
+Records path, size and mtime only -- no file contents are read -- so it costs
+directory seeks rather than a full transfer, which matters when the drive is
+failing and every read is borrowed.
+
+Written incrementally and flushed per directory, and re-running skips top-level
+directories already recorded. A disconnect therefore costs the directory in
+progress rather than the whole run, and resuming is just running it again.
+
+Compare two inventories with compare-inventory (or diff the TSVs directly);
+sizes alone are a strong identity signal for media files without hashing.
+
+Usage:
+    python inventory-drive.py <mountpoint> <output.tsv> [subdir ...] [--rescan]
+
+Source can be:
+    /media/joe/DRIVE    -- any mounted filesystem (Linux)
+    F:                  -- Windows drive letter (auto-mapped via WSL)
+
+Examples:
+    python inventory-drive.py /media/joe/RED red.tsv
+    python inventory-drive.py /media/joe/RED red.tsv Roms saved
+    python inventory-drive.py F: d-drive.tsv
+    python inventory-drive.py /mnt/backup backup.tsv --rescan
+"""
+
+import argparse
+import os
+import re
+import sys
+import time
+from typing import Set, TextIO
+
+WIN_DRIVE = re.compile(r"^([A-Za-z]):[\\/]?$")
+
+
+def win_to_wsl_path(win_path: str) -> str:
+    """Convert C:\\foo\\bar or C: to /mnt/c/foo/bar."""
+    m = WIN_DRIVE.match(win_path)
+    if m:
+        return "/mnt/" + m.group(1).lower()
+    if len(win_path) > 2 and win_path[1] == ":":
+        rest = win_path[2:].replace("\\", "/").lstrip("/")
+        return "/mnt/" + win_path[0].lower() + "/" + rest
+    return win_path
+
+
+def already_recorded(path: str) -> Set[str]:
+    """Top-level directories present in an existing inventory."""
+    tops: Set[str] = set()
+    if not os.path.exists(path):
+        return tops
+    with open(path, encoding="utf-8", errors="replace") as handle:
+        for line in handle:
+            if line.startswith("#"):
+                continue
+            first = line.split("\t", 1)[0]
+            if first:
+                tops.add(first.split("/", 1)[0])
+    return tops
+
+
+def record_tree(root: str, top: str, out: TextIO) -> "tuple[int, int]":
+    """Walk one top-level entry, writing a row per file. Returns (files, bytes)."""
+    base = os.path.join(root, top)
+    count = 0
+    total = 0
+    if os.path.isfile(base):
+        stat = os.stat(base)
+        out.write("%s\t%d\t%d\n" % (top, stat.st_size, int(stat.st_mtime)))
+        return 1, stat.st_size
+    for dirpath, dirnames, filenames in os.walk(base):
+        dirnames[:] = [d for d in dirnames if not d.startswith("$")]
+        for name in filenames:
+            full = os.path.join(dirpath, name)
+            try:
+                stat = os.stat(full)
+            except OSError:
+                continue
+            rel = os.path.relpath(full, root)
+            out.write("%s\t%d\t%d\n" % (rel, stat.st_size, int(stat.st_mtime)))
+            count += 1
+            total += stat.st_size
+        # Flush per directory: a disconnect costs one directory, not the run.
+        out.flush()
+    return count, total
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Catalogue a mounted volume (paths and sizes, no contents)."
+    )
+    parser.add_argument("mountpoint", help="mounted filesystem, or a Windows drive letter")
+    parser.add_argument("output", help="TSV to write (appended to, for resume)")
+    parser.add_argument("subdirs", nargs="*", help="limit to these top-level entries")
+    parser.add_argument("--rescan", action="store_true",
+                        help="ignore an existing inventory and start again")
+    args = parser.parse_args()
+
+    root = win_to_wsl_path(args.mountpoint).rstrip("/")
+    if not os.path.isdir(root):
+        print("not a directory: %s" % root, file=sys.stderr)
+        return 1
+
+    if args.rescan and os.path.exists(args.output):
+        os.unlink(args.output)
+    done = already_recorded(args.output)
+    if done:
+        print("resuming -- already recorded: %s" % ", ".join(sorted(done)))
+
+    try:
+        entries = sorted(
+            e for e in os.listdir(root)
+            if not e.startswith("$") and e != "System Volume Information"
+        )
+    except OSError as exc:
+        print("cannot read %s: %s" % (root, exc), file=sys.stderr)
+        return 1
+    if args.subdirs:
+        entries = [e for e in entries if e in args.subdirs]
+
+    grand_files = 0
+    grand_bytes = 0
+    with open(args.output, "a", encoding="utf-8") as out:
+        if not done:
+            out.write("#path\tsize\tmtime\n")
+        for top in entries:
+            if top in done:
+                continue
+            started = time.time()
+            try:
+                count, total = record_tree(root, top, out)
+            except OSError as exc:
+                print("  ! %-18s aborted: %s" % (top, exc))
+                out.flush()
+                continue
+            grand_files += count
+            grand_bytes += total
+            print("  %-18s %7d files  %8.1f GB  %5.0fs"
+                  % (top, count, total / 1e9, time.time() - started))
+            out.flush()
+
+    print("wrote %s -- %d files, %.1f GB this run"
+          % (args.output, grand_files, grand_bytes / 1e9))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ntfs-extract.py
+++ b/ntfs-extract.py
@@ -46,12 +46,11 @@ import shutil
 import subprocess
 import sys
 import time
-from typing import List, Tuple
 
 LISTING = re.compile(r"^\s*(\d+)\s+\w+\s+\d+\s+[\d:]+\s+\d{4}\s+(.*)$")
 
 
-def as_root(cmd: List[str]) -> List[str]:
+def as_root(cmd: list[str]) -> list[str]:
     """Prefix with sudo unless we already are root.
 
     Reading a block device needs privilege, but the *script* does not: elevating
@@ -63,7 +62,7 @@ def as_root(cmd: List[str]) -> List[str]:
     return ["sudo", "-n"] + cmd
 
 
-def listdir(device: str, path: str, timeout: int) -> List[Tuple[int, str, bool]]:
+def listdir(device: str, path: str, timeout: int) -> list[tuple[int, str, bool]]:
     """One directory as (size, name, is_dir).
 
     `-F` (classify) appends "/" to directory names. Without it a directory and a
@@ -79,7 +78,7 @@ def listdir(device: str, path: str, timeout: int) -> List[Tuple[int, str, bool]]
             capture_output=True, text=True, timeout=timeout, check=False,
         )
     except subprocess.TimeoutExpired:
-        print("  ! timed out listing %s" % path, file=sys.stderr)
+        print(f"  ! timed out listing {path}", file=sys.stderr)
         return []
     rows = []
     for line in result.stdout.splitlines():
@@ -97,9 +96,9 @@ def listdir(device: str, path: str, timeout: int) -> List[Tuple[int, str, bool]]
 
 
 def collect(device: str, path: str, depth: int, maxdepth: int,
-            timeout: int, minsize: int) -> List[Tuple[str, int]]:
+            timeout: int, minsize: int) -> list[tuple[str, int]]:
     """Every file at or under path, as (full path, size)."""
-    found: List[Tuple[str, int]] = []
+    found: list[tuple[str, int]] = []
     for size, name, is_dir in listdir(device, path, timeout):
         child = path.rstrip("/") + "/" + name
         if is_dir:
@@ -141,12 +140,12 @@ def extract(device: str, src: str, dest: str, size: int, timeout: int) -> bool:
                 stdout=handle, stderr=subprocess.PIPE, timeout=timeout, check=False,
             )
     except subprocess.TimeoutExpired:
-        print("  ! timeout: %s" % src, file=sys.stderr)
+        print(f"  ! timeout: {src}", file=sys.stderr)
         _unlink(part)
         return False
     if result.returncode != 0:
         detail = result.stderr.decode("utf-8", "replace").strip().splitlines()
-        print("  ! failed: %s -- %s" % (src, detail[-1] if detail else "unknown"),
+        print("  ! failed: {} -- {}".format(src, detail[-1] if detail else "unknown"),
               file=sys.stderr)
         _unlink(part)
         return False
@@ -185,13 +184,13 @@ def main() -> int:
 
     for tool in ("ntfsls", "ntfscat"):
         if shutil.which(tool) is None:
-            print("%s not found -- install the ntfs-3g package" % tool, file=sys.stderr)
+            print(f"{tool} not found -- install the ntfs-3g package", file=sys.stderr)
             return 1
 
-    print("enumerating %s ..." % args.path)
+    print(f"enumerating {args.path} ...")
     files = collect(args.device, args.path, 0, args.depth, 60, args.min_size)
     if not files:
-        print("nothing found at %s" % args.path, file=sys.stderr)
+        print(f"nothing found at {args.path}", file=sys.stderr)
         return 1
     total = sum(size for _, size in files)
     print("  %d files, %.1f GB" % (len(files), total / 1e9))
@@ -199,7 +198,7 @@ def main() -> int:
     base = args.path.rstrip("/")
     if args.dry_run:
         for src, size in files[:20]:
-            print("  %10.1f MB  %s" % (size / 1e6, src))
+            print(f"  {size / 1e6:10.1f} MB  {src}")
         if len(files) > 20:
             print("  ... and %d more" % (len(files) - 20))
         print("dry run -- nothing written")

--- a/ntfs-extract.py
+++ b/ntfs-extract.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python
+"""
+JP_TOOLS/ntfs-extract.py
+Copy a directory tree off an NTFS volume that will not mount.
+
+When a volume's metadata is partly unreadable the kernel driver refuses to
+mount it, but the files themselves are usually fine. ntfsls and ntfscat read
+the $MFT directly, so a tree can be enumerated and extracted without mounting
+anything.
+
+Measured case: a 2TB drive that failed to mount with
+
+    Failed to read NTFS $Bitmap: Input/output error
+
+$Bitmap is the cluster allocation map, which ntfs-3g reads at mount time and
+which nothing needs in order to *read* a file. ntfsls and ntfscat never touch
+it, so 356 GB across 1183 files came off a volume the kernel would not mount.
+
+Resumable and fault-tolerant by design: a file already present at the
+destination with the expected size is skipped, and a file that fails to read is
+logged and stepped over rather than aborting the run. On a failing drive the
+goal is to take everything readable in one pass and know exactly what was lost.
+
+Everything is read-only with respect to the source. Never run a repair tool on
+a disk you have not copied yet -- repair writes, and writing to a disk with
+pending sectors is how a recoverable situation becomes an unrecoverable one.
+
+Requires ntfsls and ntfscat (ntfs-3g package). Reading a block device needs
+privilege, so those two are invoked via sudo when not already root -- a
+sudoers rule covering just them is enough, no need to run this as root.
+
+Usage:
+    python ntfs-extract.py <device> <path> <destination> [--dry-run]
+                                [--depth N] [--min-size BYTES]
+
+Examples:
+    python ntfs-extract.py /dev/sdb3 /Movies/tv ~/rescue/tv
+    python ntfs-extract.py /dev/sdb3 /Movies ~/rescue/movies --dry-run
+    python ntfs-extract.py /dev/sdb3 /Photos ~/rescue --depth 6
+"""
+
+import argparse
+import os
+import re
+import shutil
+import subprocess
+import sys
+import time
+from typing import List, Tuple
+
+LISTING = re.compile(r"^\s*(\d+)\s+\w+\s+\d+\s+[\d:]+\s+\d{4}\s+(.*)$")
+
+
+def as_root(cmd: List[str]) -> List[str]:
+    """Prefix with sudo unless we already are root.
+
+    Reading a block device needs privilege, but the *script* does not: elevating
+    only ntfsls/ntfscat means a narrow sudoers rule covering those two binaries
+    is enough, rather than granting the interpreter.
+    """
+    if os.geteuid() == 0:
+        return cmd
+    return ["sudo", "-n"] + cmd
+
+
+def listdir(device: str, path: str, timeout: int) -> List[Tuple[int, str]]:
+    """One directory as (size, name). Directories report size 0."""
+    try:
+        result = subprocess.run(
+            as_root(["ntfsls", "-l", "-p", path, device]),
+            capture_output=True, text=True, timeout=timeout, check=False,
+        )
+    except subprocess.TimeoutExpired:
+        print("  ! timed out listing %s" % path, file=sys.stderr)
+        return []
+    rows = []
+    for line in result.stdout.splitlines():
+        match = LISTING.match(line)
+        if not match:
+            continue
+        name = match.group(2).strip()
+        if name in (".", ".."):
+            continue
+        rows.append((int(match.group(1)), name))
+    return rows
+
+
+def collect(device: str, path: str, depth: int, maxdepth: int,
+            timeout: int, minsize: int) -> List[Tuple[str, int]]:
+    """Every file at or under path, as (full path, size)."""
+    found: List[Tuple[str, int]] = []
+    for size, name in listdir(device, path, timeout):
+        child = path.rstrip("/") + "/" + name
+        if size == 0:
+            if depth < maxdepth:
+                found.extend(collect(device, child, depth + 1, maxdepth,
+                                     timeout, minsize))
+        elif size >= minsize:
+            found.append((child, size))
+    return found
+
+
+def extract(device: str, src: str, dest: str, size: int, timeout: int) -> bool:
+    """Pull one file out. Writes to a .part file and renames on success, so an
+    interrupted extraction is never mistaken for a complete one."""
+    part = dest + ".part"
+    os.makedirs(os.path.dirname(dest), exist_ok=True)
+    try:
+        with open(part, "wb") as handle:
+            result = subprocess.run(
+                as_root(["ntfscat", device, src]),
+                stdout=handle, stderr=subprocess.PIPE, timeout=timeout, check=False,
+            )
+    except subprocess.TimeoutExpired:
+        print("  ! timeout: %s" % src, file=sys.stderr)
+        _unlink(part)
+        return False
+    if result.returncode != 0:
+        detail = result.stderr.decode("utf-8", "replace").strip().splitlines()
+        print("  ! failed: %s -- %s" % (src, detail[-1] if detail else "unknown"),
+              file=sys.stderr)
+        _unlink(part)
+        return False
+    if os.path.getsize(part) != size:
+        print("  ! short read: %s (%d of %d bytes)"
+              % (src, os.path.getsize(part), size), file=sys.stderr)
+        _unlink(part)
+        return False
+    os.replace(part, dest)
+    return True
+
+
+def _unlink(path: str) -> None:
+    try:
+        os.unlink(path)
+    except OSError:
+        pass
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Copy a tree off an NTFS volume that will not mount."
+    )
+    parser.add_argument("device", help="NTFS partition, e.g. /dev/sdb3")
+    parser.add_argument("path", help="path within the volume, e.g. /Movies/tv")
+    parser.add_argument("destination", help="directory to write into")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="list what would be copied and stop")
+    parser.add_argument("--depth", type=int, default=6,
+                        help="how deep to recurse (default 6)")
+    parser.add_argument("--min-size", type=int, default=0,
+                        help="skip files smaller than this many bytes")
+    parser.add_argument("--timeout", type=int, default=1800,
+                        help="seconds to allow per file (default 1800)")
+    args = parser.parse_args()
+
+    for tool in ("ntfsls", "ntfscat"):
+        if shutil.which(tool) is None:
+            print("%s not found -- install the ntfs-3g package" % tool, file=sys.stderr)
+            return 1
+
+    print("enumerating %s ..." % args.path)
+    files = collect(args.device, args.path, 0, args.depth, 60, args.min_size)
+    if not files:
+        print("nothing found at %s" % args.path, file=sys.stderr)
+        return 1
+    total = sum(size for _, size in files)
+    print("  %d files, %.1f GB" % (len(files), total / 1e9))
+
+    base = args.path.rstrip("/")
+    if args.dry_run:
+        for src, size in files[:20]:
+            print("  %10.1f MB  %s" % (size / 1e6, src))
+        if len(files) > 20:
+            print("  ... and %d more" % (len(files) - 20))
+        print("dry run -- nothing written")
+        return 0
+
+    copied = skipped = failed = 0
+    done_bytes = 0
+    started = time.time()
+    for src, size in files:
+        rel = src[len(base):].lstrip("/")
+        dest = os.path.join(args.destination, rel)
+        if os.path.exists(dest) and os.path.getsize(dest) == size:
+            skipped += 1
+            done_bytes += size
+            continue
+        if extract(args.device, src, dest, size, args.timeout):
+            copied += 1
+            done_bytes += size
+        else:
+            failed += 1
+        elapsed = time.time() - started
+        if (copied + failed) % 10 == 0 and elapsed > 0:
+            print("  %d/%d  %.1f GB  %.1f MB/s"
+                  % (copied + skipped + failed, len(files),
+                     done_bytes / 1e9, done_bytes / 1e6 / elapsed))
+
+    print("copied %d, skipped %d already present, failed %d"
+          % (copied, skipped, failed))
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ntfs-extract.py
+++ b/ntfs-extract.py
@@ -63,11 +63,19 @@ def as_root(cmd: List[str]) -> List[str]:
     return ["sudo", "-n"] + cmd
 
 
-def listdir(device: str, path: str, timeout: int) -> List[Tuple[int, str]]:
-    """One directory as (size, name). Directories report size 0."""
+def listdir(device: str, path: str, timeout: int) -> List[Tuple[int, str, bool]]:
+    """One directory as (size, name, is_dir).
+
+    `-F` (classify) appends "/" to directory names. Without it a directory and a
+    zero-byte file are indistinguishable, because ntfsls reports size 0 for
+    both -- verified against a scratch NTFS image, where the `$Extend` directory
+    and the empty `$Secure` file both list as 0. Branching on size alone treated
+    every empty file as a directory, so empty files were silently never copied.
+    NTFS forbids "/" in a name, so the marker is unambiguous.
+    """
     try:
         result = subprocess.run(
-            as_root(["ntfsls", "-l", "-p", path, device]),
+            as_root(["ntfsls", "-l", "-F", "-p", path, device]),
             capture_output=True, text=True, timeout=timeout, check=False,
         )
     except subprocess.TimeoutExpired:
@@ -79,9 +87,12 @@ def listdir(device: str, path: str, timeout: int) -> List[Tuple[int, str]]:
         if not match:
             continue
         name = match.group(2).strip()
+        is_dir = name.endswith("/")
+        if is_dir:
+            name = name[:-1]
         if name in (".", ".."):
             continue
-        rows.append((int(match.group(1)), name))
+        rows.append((int(match.group(1)), name, is_dir))
     return rows
 
 
@@ -89,15 +100,33 @@ def collect(device: str, path: str, depth: int, maxdepth: int,
             timeout: int, minsize: int) -> List[Tuple[str, int]]:
     """Every file at or under path, as (full path, size)."""
     found: List[Tuple[str, int]] = []
-    for size, name in listdir(device, path, timeout):
+    for size, name, is_dir in listdir(device, path, timeout):
         child = path.rstrip("/") + "/" + name
-        if size == 0:
+        if is_dir:
             if depth < maxdepth:
                 found.extend(collect(device, child, depth + 1, maxdepth,
                                      timeout, minsize))
+            else:
+                # Say so. A silently truncated tree looks exactly like a
+                # complete one in the totals, which in a recovery means
+                # believing you have everything when you do not.
+                print(f"  ! depth limit {maxdepth} reached, "
+                      f"not descending into {child}", file=sys.stderr)
         elif size >= minsize:
             found.append((child, size))
     return found
+
+
+def within(root: str, candidate: str) -> bool:
+    """True if candidate resolves inside root.
+
+    Names come from a filesystem damaged enough that the kernel refuses to mount
+    it, and this may run as root. A ".." surviving into the relative path would
+    otherwise write outside the destination.
+    """
+    root_abs = os.path.abspath(root)
+    cand_abs = os.path.abspath(candidate)
+    return cand_abs == root_abs or cand_abs.startswith(root_abs + os.sep)
 
 
 def extract(device: str, src: str, dest: str, size: int, timeout: int) -> bool:
@@ -182,6 +211,10 @@ def main() -> int:
     for src, size in files:
         rel = src[len(base):].lstrip("/")
         dest = os.path.join(args.destination, rel)
+        if not within(args.destination, dest):
+            print(f"  ! refusing path outside destination: {src}", file=sys.stderr)
+            failed += 1
+            continue
         if os.path.exists(dest) and os.path.getsize(dest) == size:
             skipped += 1
             done_bytes += size

--- a/ntfs-inventory.py
+++ b/ntfs-inventory.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Inventory an unmountable NTFS volume via ntfsls -- metadata only.
+
+The lightest operation available on a failing drive: directory entries only, no
+file data. Written incrementally per top-level directory and resumable, so a
+disconnect costs the directory in progress rather than the run.
+"""
+import os
+import re
+import subprocess
+import sys
+
+LISTING = re.compile(r"^\s*(\d+)\s+\w+\s+\d+\s+[\d:]+\s+\d{4}\s+(.*)$")
+
+USAGE = """usage: ntfs-inventory.py DEVICE OUTPUT.tsv [DIR ...]
+
+  DEVICE   the NTFS partition, e.g. /dev/sdb3 -- it does NOT need to mount
+  OUTPUT   TSV written as "path<TAB>size"; appended to and resumable
+  DIR      optional top-level directories to limit the pass to
+
+Needs ntfsls (ntfs-3g), and root or passwordless sudo for the raw device.
+Re-running the same command resumes: any top-level directory already present
+in OUTPUT is skipped."""
+
+if len(sys.argv) < 3 or sys.argv[1] in ("-h", "--help"):
+    print(USAGE)
+    sys.exit(0 if len(sys.argv) > 1 and sys.argv[1] in ("-h", "--help") else 2)
+
+DEV, OUT = sys.argv[1], sys.argv[2]
+ONLY = sys.argv[3:] or None
+
+
+def as_root(cmd):
+    return cmd if os.geteuid() == 0 else ["sudo", "-n"] + cmd
+
+
+def listdir(path):
+    try:
+        r = subprocess.run(as_root(["ntfsls", "-l", "-p", path, DEV]),
+                           capture_output=True, text=True, timeout=90, check=False)
+    except subprocess.TimeoutExpired:
+        print("  ! timeout: %s" % path, file=sys.stderr)
+        return []
+    rows = []
+    for line in r.stdout.splitlines():
+        m = LISTING.match(line)
+        if m and m.group(2).strip() not in (".", ".."):
+            rows.append((int(m.group(1)), m.group(2).strip()))
+    return rows
+
+
+def walk(path, out, depth=0, maxdepth=8):
+    n = b = 0
+    for size, name in listdir(path):
+        child = path.rstrip("/") + "/" + name
+        if size == 0 and depth < maxdepth:
+            sn, sb = walk(child, out, depth + 1, maxdepth)
+            n += sn
+            b += sb
+        else:
+            out.write("%s\t%d\n" % (child, size))
+            n += 1
+            b += size
+    out.flush()
+    return n, b
+
+
+done = set()
+if os.path.exists(OUT):
+    for line in open(OUT, encoding="utf-8", errors="replace"):
+        if not line.startswith("#"):
+            done.add(line.split("\t")[0].lstrip("/").split("/", 1)[0])
+    if done:
+        print("resuming -- done: %s" % ", ".join(sorted(done)))
+
+tops = [(s, n) for s, n in listdir("/")
+        if not n.startswith("$") and n != "System Volume Information"]
+if ONLY:
+    tops = [(s, n) for s, n in tops if n in ONLY]
+
+with open(OUT, "a", encoding="utf-8") as out:
+    if not done:
+        out.write("#path\tsize\n")
+    for size, name in tops:
+        if name in done:
+            continue
+        if size:
+            out.write("/%s\t%d\n" % (name, size))
+            print("  %-24s %7d files %8.1f GB" % (name, 1, size / 1e9))
+            continue
+        n, b = walk("/" + name, out)
+        print("  %-24s %7d files %8.1f GB" % (name[:24], n, b / 1e9))
+print("wrote %s" % OUT)

--- a/ntfs-inventory.py
+++ b/ntfs-inventory.py
@@ -39,7 +39,7 @@ def listdir(path):
         r = subprocess.run(as_root(["ntfsls", "-l", "-F", "-p", path, DEV]),
                            capture_output=True, text=True, timeout=90, check=False)
     except subprocess.TimeoutExpired:
-        print("  ! timeout: %s" % path, file=sys.stderr)
+        print(f"  ! timeout: {path}", file=sys.stderr)
         return []
     rows = []
     for line in r.stdout.splitlines():
@@ -85,23 +85,23 @@ if os.path.exists(OUT):
         if not line.startswith("#"):
             done.add(line.split("\t")[0].lstrip("/").split("/", 1)[0])
     if done:
-        print("resuming -- done: %s" % ", ".join(sorted(done)))
+        print("resuming -- done: {}".format(", ".join(sorted(done))))
 
-tops = [(s, n) for s, n in listdir("/")
+tops = [(s, n, d) for s, n, d in listdir("/")
         if not n.startswith("$") and n != "System Volume Information"]
 if ONLY:
-    tops = [(s, n) for s, n in tops if n in ONLY]
+    tops = [(s, n, d) for s, n, d in tops if n in ONLY]
 
 with open(OUT, "a", encoding="utf-8") as out:
     if not done:
         out.write("#path\tsize\n")
-    for size, name in tops:
+    for size, name, is_dir in tops:
         if name in done:
             continue
-        if size:
+        if not is_dir:
             out.write("/%s\t%d\n" % (name, size))
             print("  %-24s %7d files %8.1f GB" % (name, 1, size / 1e9))
             continue
         n, b = walk("/" + name, out)
         print("  %-24s %7d files %8.1f GB" % (name[:24], n, b / 1e9))
-print("wrote %s" % OUT)
+print(f"wrote {OUT}")

--- a/ntfs-inventory.py
+++ b/ntfs-inventory.py
@@ -36,7 +36,7 @@ def as_root(cmd):
 
 def listdir(path):
     try:
-        r = subprocess.run(as_root(["ntfsls", "-l", "-p", path, DEV]),
+        r = subprocess.run(as_root(["ntfsls", "-l", "-F", "-p", path, DEV]),
                            capture_output=True, text=True, timeout=90, check=False)
     except subprocess.TimeoutExpired:
         print("  ! timeout: %s" % path, file=sys.stderr)
@@ -44,19 +44,33 @@ def listdir(path):
     rows = []
     for line in r.stdout.splitlines():
         m = LISTING.match(line)
-        if m and m.group(2).strip() not in (".", ".."):
-            rows.append((int(m.group(1)), m.group(2).strip()))
+        if not m:
+            continue
+        name = m.group(2).strip()
+        is_dir = name.endswith("/")
+        if is_dir:
+            name = name[:-1]
+        if name in (".", ".."):
+            continue
+        rows.append((int(m.group(1)), name, is_dir))
     return rows
 
 
 def walk(path, out, depth=0, maxdepth=8):
     n = b = 0
-    for size, name in listdir(path):
+    for size, name, is_dir in listdir(path):
         child = path.rstrip("/") + "/" + name
-        if size == 0 and depth < maxdepth:
-            sn, sb = walk(child, out, depth + 1, maxdepth)
-            n += sn
-            b += sb
+        # -F marks directories. Branching on size alone recorded every empty
+        # file as a directory, and at the depth limit recorded every directory
+        # as a 0-byte file.
+        if is_dir:
+            if depth < maxdepth:
+                sn, sb = walk(child, out, depth + 1, maxdepth)
+                n += sn
+                b += sb
+            else:
+                print(f"  ! depth limit {maxdepth} reached, "
+                      f"not descending into {child}", file=sys.stderr)
         else:
             out.write("%s\t%d\n" % (child, size))
             n += 1

--- a/ntfs-size.py
+++ b/ntfs-size.py
@@ -58,7 +58,7 @@ def listdir(device: str, path: str, timeout: int) -> List[Tuple[int, str]]:
     """One directory, as (size, name). Directories report size 0."""
     try:
         result = subprocess.run(
-            as_root(["ntfsls", "-l", "-p", path, device]),
+            as_root(["ntfsls", "-l", "-F", "-p", path, device]),
             capture_output=True, text=True, timeout=timeout, check=False,
         )
     except subprocess.TimeoutExpired:
@@ -70,9 +70,12 @@ def listdir(device: str, path: str, timeout: int) -> List[Tuple[int, str]]:
         if not match:
             continue
         name = match.group(2).strip()
+        is_dir = name.endswith("/")
+        if is_dir:
+            name = name[:-1]
         if name in (".", ".."):
             continue
-        rows.append((int(match.group(1)), name))
+        rows.append((int(match.group(1)), name, is_dir))
     return rows
 
 
@@ -81,15 +84,19 @@ def walk(device: str, path: str, depth: int, maxdepth: int,
     """Recursive size of one subtree. Returns (bytes, files)."""
     total = 0
     files = 0
-    for size, name in listdir(device, path, timeout):
+    for size, name, is_dir in listdir(device, path, timeout):
         child = path.rstrip("/") + "/" + name
-        # ntfsls reports 0 for directories; recurse until the depth limit, then
-        # stop rather than guessing -- an under-count is obvious, a wrong number
-        # is not.
-        if size == 0 and depth < maxdepth:
-            sub_total, sub_files = walk(device, child, depth + 1, maxdepth, timeout)
-            total += sub_total
-            files += sub_files
+        # -F marks directories, so an empty file is no longer mistaken for one.
+        # At the depth limit, stop and say so rather than counting the directory
+        # itself as a 0-byte file, which quietly under-counted the subtree.
+        if is_dir:
+            if depth < maxdepth:
+                sub_total, sub_files = walk(device, child, depth + 1, maxdepth, timeout)
+                total += sub_total
+                files += sub_files
+            else:
+                print(f"  ! depth limit {maxdepth} reached, "
+                      f"not descending into {child}", file=sys.stderr)
         else:
             total += size
             files += 1

--- a/ntfs-size.py
+++ b/ntfs-size.py
@@ -36,13 +36,12 @@ import re
 import shutil
 import subprocess
 import sys
-from typing import List, Tuple
 
 # ntfsls -l prints: size, month, day, time, year, name
 LISTING = re.compile(r"^\s*(\d+)\s+\w+\s+\d+\s+[\d:]+\s+\d{4}\s+(.*)$")
 
 
-def as_root(cmd: List[str]) -> List[str]:
+def as_root(cmd: list[str]) -> list[str]:
     """Prefix with sudo unless we already are root.
 
     Reading a block device needs privilege, but the *script* does not: elevating
@@ -54,15 +53,20 @@ def as_root(cmd: List[str]) -> List[str]:
     return ["sudo", "-n"] + cmd
 
 
-def listdir(device: str, path: str, timeout: int) -> List[Tuple[int, str]]:
-    """One directory, as (size, name). Directories report size 0."""
+def listdir(device: str, path: str, timeout: int) -> list[tuple[int, str, bool]]:
+    """One directory, as (size, name, is_dir).
+
+    `-F` (classify) appends "/" to directory names. ntfsls reports size 0 for
+    both a directory and an empty file, so size alone cannot tell them apart.
+    NTFS forbids "/" in a name, so the marker is unambiguous.
+    """
     try:
         result = subprocess.run(
             as_root(["ntfsls", "-l", "-F", "-p", path, device]),
             capture_output=True, text=True, timeout=timeout, check=False,
         )
     except subprocess.TimeoutExpired:
-        print("  ! timed out listing %s" % path, file=sys.stderr)
+        print(f"  ! timed out listing {path}", file=sys.stderr)
         return []
     rows = []
     for line in result.stdout.splitlines():
@@ -80,7 +84,7 @@ def listdir(device: str, path: str, timeout: int) -> List[Tuple[int, str]]:
 
 
 def walk(device: str, path: str, depth: int, maxdepth: int,
-         timeout: int) -> Tuple[int, int]:
+         timeout: int) -> tuple[int, int]:
     """Recursive size of one subtree. Returns (bytes, files)."""
     total = 0
     files = 0
@@ -123,13 +127,13 @@ def main() -> int:
 
     entries = listdir(args.device, args.path, args.timeout)
     if not entries:
-        print("nothing listed at %s on %s" % (args.path, args.device), file=sys.stderr)
+        print(f"nothing listed at {args.path} on {args.device}", file=sys.stderr)
         print("(is it an NTFS partition, and are you root?)", file=sys.stderr)
         return 1
 
     rows = []
-    for size, name in entries:
-        if size:
+    for size, name, is_dir in entries:
+        if not is_dir:
             rows.append((size, 1, name))
             continue
         child = args.path.rstrip("/") + "/" + name

--- a/ntfs-size.py
+++ b/ntfs-size.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python
+"""
+JP_TOOLS/ntfs-size.py
+Size a directory tree on an NTFS volume that will not mount.
+
+Decide whether something is worth recovering *before* imaging it. When a
+volume's $MFT is damaged the kernel driver refuses to mount, but ntfsls parses
+the MFT directly -- the same way testdisk does -- so directories can still be
+listed and measured. A listing costs a fraction of what a transfer costs, which
+matters when the drive is failing.
+
+Measured on a 2TB drive whose $MFT was damaged 3.2 GB in: the volume would not
+mount at all, yet this reported 356 GB across 1183 files in 205 directories
+without reading a byte of file data.
+
+Requires ntfsls (ntfs-3g package). Reading a block device needs privilege,
+so ntfsls is invoked via sudo when not already root -- a sudoers rule
+covering just that binary is enough, no need to run this as root.
+Everything it does is read-only -- it never writes to the volume, which matters
+because repair tools do, and writing to a disk with pending sectors is how a
+recoverable situation becomes an unrecoverable one.
+
+Usage:
+    python ntfs-size.py <device> [path] [--depth N] [--top N]
+
+Examples:
+    python ntfs-size.py /dev/sdb3
+    python ntfs-size.py /dev/sdb3 /Movies
+    python ntfs-size.py /dev/sdb3 /Movies --depth 4
+    python ntfs-size.py /dev/sdb3 / --top 20
+"""
+
+import argparse
+import os
+import re
+import shutil
+import subprocess
+import sys
+from typing import List, Tuple
+
+# ntfsls -l prints: size, month, day, time, year, name
+LISTING = re.compile(r"^\s*(\d+)\s+\w+\s+\d+\s+[\d:]+\s+\d{4}\s+(.*)$")
+
+
+def as_root(cmd: List[str]) -> List[str]:
+    """Prefix with sudo unless we already are root.
+
+    Reading a block device needs privilege, but the *script* does not: elevating
+    only ntfsls/ntfscat means a narrow sudoers rule covering those two binaries
+    is enough, rather than granting the interpreter.
+    """
+    if os.geteuid() == 0:
+        return cmd
+    return ["sudo", "-n"] + cmd
+
+
+def listdir(device: str, path: str, timeout: int) -> List[Tuple[int, str]]:
+    """One directory, as (size, name). Directories report size 0."""
+    try:
+        result = subprocess.run(
+            as_root(["ntfsls", "-l", "-p", path, device]),
+            capture_output=True, text=True, timeout=timeout, check=False,
+        )
+    except subprocess.TimeoutExpired:
+        print("  ! timed out listing %s" % path, file=sys.stderr)
+        return []
+    rows = []
+    for line in result.stdout.splitlines():
+        match = LISTING.match(line)
+        if not match:
+            continue
+        name = match.group(2).strip()
+        if name in (".", ".."):
+            continue
+        rows.append((int(match.group(1)), name))
+    return rows
+
+
+def walk(device: str, path: str, depth: int, maxdepth: int,
+         timeout: int) -> Tuple[int, int]:
+    """Recursive size of one subtree. Returns (bytes, files)."""
+    total = 0
+    files = 0
+    for size, name in listdir(device, path, timeout):
+        child = path.rstrip("/") + "/" + name
+        # ntfsls reports 0 for directories; recurse until the depth limit, then
+        # stop rather than guessing -- an under-count is obvious, a wrong number
+        # is not.
+        if size == 0 and depth < maxdepth:
+            sub_total, sub_files = walk(device, child, depth + 1, maxdepth, timeout)
+            total += sub_total
+            files += sub_files
+        else:
+            total += size
+            files += 1
+    return total, files
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Size an NTFS directory tree without mounting the volume."
+    )
+    parser.add_argument("device", help="NTFS partition, e.g. /dev/sdb3")
+    parser.add_argument("path", nargs="?", default="/", help="path within the volume")
+    parser.add_argument("--depth", type=int, default=4,
+                        help="how deep to recurse below each entry (default 4)")
+    parser.add_argument("--top", type=int, default=0,
+                        help="show only the N largest entries")
+    parser.add_argument("--timeout", type=int, default=60,
+                        help="seconds to allow per directory listing")
+    args = parser.parse_args()
+
+    if shutil.which("ntfsls") is None:
+        print("ntfsls not found -- install the ntfs-3g package", file=sys.stderr)
+        return 1
+
+    entries = listdir(args.device, args.path, args.timeout)
+    if not entries:
+        print("nothing listed at %s on %s" % (args.path, args.device), file=sys.stderr)
+        print("(is it an NTFS partition, and are you root?)", file=sys.stderr)
+        return 1
+
+    rows = []
+    for size, name in entries:
+        if size:
+            rows.append((size, 1, name))
+            continue
+        child = args.path.rstrip("/") + "/" + name
+        total, files = walk(args.device, child, 1, args.depth, args.timeout)
+        rows.append((total, files, name))
+
+    rows.sort(reverse=True)
+    if args.top:
+        rows = rows[: args.top]
+
+    grand = 0
+    count = 0
+    for total, files, name in rows:
+        print("  %-40s %10.2f GB  %7d files" % (name[:40], total / 1e9, files))
+        grand += total
+        count += files
+    print("  %-40s %10.2f GB  %7d files" % ("TOTAL", grand / 1e9, count))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_ntfs_recovery.py
+++ b/tests/test_ntfs_recovery.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python
+"""
+JP_TOOLS/tests/test_ntfs_recovery.py
+Tests for the NTFS recovery tools, against a real NTFS filesystem.
+
+Builds a small NTFS image with mkntfs, seeds it with the case that used to be
+mishandled, and drives the tools' own functions against it. No pytest, no
+dependencies -- the toolbox has none and this should not add the first.
+
+THE BUG THIS PINS DOWN
+    ntfsls reports size 0 for a directory *and* for an empty file, so code that
+    branched on size treated every zero-byte file as a directory: it recursed
+    into it, found nothing, and never copied it. On a recovery pass that is
+    silent data loss, and the file count looks correct either way.
+
+    Measured before the fix, on an image holding four files: collect() returned
+    one of them.
+
+Skips rather than fails when the environment cannot support it:
+  - no ntfsls/ntfscat/mkntfs  -> skip (ntfs-3g not installed)
+  - cannot mount              -> the directory-recursion checks are skipped;
+                                 mounting needs root, and everything else still
+                                 runs unprivileged against the image file
+
+    python tests/test_ntfs_recovery.py
+"""
+
+import contextlib
+import importlib.util
+import io
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+REQUIRED = ("mkntfs", "ntfsls", "ntfscat", "ntfscp")
+
+
+def load(name: str, path: Path):
+    """Import a hyphenated script by path."""
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"cannot load {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def build_image(directory: Path) -> Path:
+    """A 20MB NTFS volume holding an empty file and a normal one."""
+    image = directory / "test.ntfs"
+    with open(image, "wb") as handle:
+        handle.truncate(20 * 1024 * 1024)
+    subprocess.run(["mkntfs", "-F", "-q", "-L", "jptest", str(image)],
+                   check=True, capture_output=True)
+
+    empty = directory / "empty.bin"
+    empty.touch()
+    small = directory / "small.bin"
+    small.write_text("hello world")
+    for source, name in ((empty, "/empty.bin"), (small, "/small.bin")):
+        subprocess.run(["ntfscp", "-f", str(image), str(source), name],
+                       check=True, capture_output=True)
+    return image
+
+
+def add_directories(image: Path, mountpoint: Path) -> bool:
+    """Create a real directory tree inside the image. Needs root; may fail."""
+    mountpoint.mkdir(exist_ok=True)
+    try:
+        subprocess.run(["mount", "-o", "loop", str(image), str(mountpoint)],
+                       check=True, capture_output=True)
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return False
+    try:
+        (mountpoint / "realdir" / "deeper").mkdir(parents=True, exist_ok=True)
+        (mountpoint / "realdir" / "inner.bin").touch()
+        (mountpoint / "realdir" / "deeper" / "deep.bin").touch()
+    finally:
+        subprocess.run(["umount", str(mountpoint)], check=False, capture_output=True)
+    return True
+
+
+def main() -> int:
+    missing = [t for t in REQUIRED if shutil.which(t) is None]
+    if missing:
+        print(f"SKIP: ntfs-3g tools not installed ({', '.join(missing)})")
+        return 0
+
+    extract = load("ntfs_extract", ROOT / "ntfs-extract.py")
+    # The image is a plain file, so no privilege is needed to read it.
+    extract.as_root = lambda cmd: cmd
+
+    failures = []
+
+    def check(condition: bool, message: str) -> None:
+        if not condition:
+            failures.append(message)
+
+    with tempfile.TemporaryDirectory() as tmp:
+        directory = Path(tmp)
+        image = build_image(directory)
+        have_dirs = add_directories(image, directory / "mnt")
+
+        rows = extract.listdir(str(image), "/", 30)
+        entries = {name: (size, is_dir) for size, name, is_dir in rows}
+        check(bool(rows), "listdir returned nothing")
+
+        # An empty file must be a FILE. Branching on size made it a directory.
+        check(entries.get("empty.bin") == (0, False),
+              f"empty.bin should be (0, False), got {entries.get('empty.bin')}")
+        check(entries.get("small.bin") == (11, False),
+              f"small.bin should be (11, False), got {entries.get('small.bin')}")
+        check(not any(n.endswith("/") for n in entries),
+              "classify marker was not stripped from a name")
+
+        found = {path for path, _ in extract.collect(str(image), "/", 0, 6, 30, 0)}
+        check("/empty.bin" in found,
+              "collect() dropped the zero-byte file (silent data loss)")
+        check("/small.bin" in found, "collect() dropped /small.bin")
+
+        if have_dirs:
+            check(entries.get("realdir") == (0, True),
+                  f"realdir should be (0, True), got {entries.get('realdir')}")
+            for path in ("/realdir/inner.bin", "/realdir/deeper/deep.bin"):
+                check(path in found, f"collect() did not recurse to {path}")
+
+            # The depth limit must announce itself; a truncated tree otherwise
+            # looks exactly like a complete one.
+            buffer = io.StringIO()
+            with contextlib.redirect_stderr(buffer):
+                shallow = {p for p, _ in extract.collect(str(image), "/", 0, 1, 30, 0)}
+            warned = buffer.getvalue()
+            check("/realdir/deeper/deep.bin" not in shallow,
+                  "depth limit did not actually stop the walk")
+            check("depth limit" in warned,
+                  "depth limit truncated the walk silently")
+        else:
+            print("  note: mounting needs root, so directory recursion and the "
+                  "depth warning were not exercised")
+
+    # Containment: names come off a damaged volume and this may run as root.
+    for root, candidate, expected in (
+        ("/dest", "/dest/sub/file.bin", True),
+        ("/dest", "/dest/../../etc/passwd", False),
+        ("/dest", "/dest", True),
+        ("/dest", "/destination/other", False),
+    ):
+        actual = extract.within(root, candidate)
+        check(actual == expected,
+              f"within({root!r}, {candidate!r}) = {actual}, expected {expected}")
+
+    # The sibling tools share the classification, so pin it there too. They are
+    # read as source: ntfs-inventory.py parses argv at import, so it cannot be
+    # imported without exiting.
+    for name in ("ntfs-size.py", "ntfs-inventory.py"):
+        source = (ROOT / name).read_text(encoding="utf-8")
+        check('"-F"' in source, f"{name} does not pass -F to ntfsls")
+        check("is_dir" in source, f"{name} still classifies by size")
+
+    if failures:
+        print("FAIL")
+        for failure in failures:
+            print(f"  - {failure}")
+        return 1
+    count = 16 if have_dirs else 11
+    note = "" if have_dirs else " (directory cases skipped, needs root)"
+    print(f"PASS: {count} checks{note}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Fills the gap between imaging and carving: what to do when filesystem metadata is damaged, the files are fine, and a full image will not fit anywhere.

All three came out of a real recovery — a 2TB Seagate with 204 reallocated sectors, 84 pending and 3751 reported uncorrectables that stopped mounting mid-session.

## `ntfs-extract.py`
Copies a tree off an **unmountable** NTFS volume. The failure that prompted it:

```
Failed to read NTFS $Bitmap: Input/output error
```

`$Bitmap` is the cluster allocation map — ntfs-3g reads it at mount time, and nothing needs it to *read* a file. `ntfsls`/`ntfscat` parse the `$MFT` directly, so they work where the kernel refuses. **356 GB across 1183 files** came off that way.

Resumable (a destination file of the expected size is skipped) and fault-tolerant (an unreadable file is logged and stepped over, not fatal). Writes to `.part` and renames on success, so an interrupted copy is never mistaken for a complete one; size is checked against the directory entry.

## `ntfs-size.py`
Answers *"is this worth recovering"* **before** committing to a transfer. Same technique, listing only — it reported 356 GB across 205 directories without reading a byte of file data, which is what made it possible to decline a 1.1 TB copy and take only the 393 GB that existed nowhere else.

## `inventory-drive.py`
Catalogues a mounted volume as path/size/mtime so two drives can be compared later **without both being attached**. `find-dupes.php` already compares two trees, but needs both present and hashes contents; this is the offline case. Incremental and resumable — flushed per directory, and re-running skips top-level directories already recorded.

Comparing inventories is what cut that rescue from 1.1 TB to 393 GB: it showed the failing drive’s Wii and PS1 collections were already duplicated elsewhere.

## Notes

- **Read-only with respect to the source, deliberately.** No repair tool is invoked and none should be until a copy exists — repair writes, and writing to a disk with pending sectors is how a recoverable situation becomes an unrecoverable one.
- The NTFS tools shell out via `sudo` only when not already root, so a sudoers rule covering just `ntfsls`/`ntfscat` suffices rather than granting the interpreter.
- `check.py`: 0 errors, 0 warnings each.