### PR TITLE
Pin ruff and mypy, and fix the self-check violations they now report

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -15,13 +15,22 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
-      - run: pip install ruff mypy
+      # Pinned deliberately. Unpinned, this said `pip install ruff mypy`, and the
+      # build went red in August against code that had not changed since April —
+      # new linter releases added rules while the source stood still. Bump these
+      # on purpose, with the fixes in the same commit, rather than discovering it
+      # in whichever unrelated PR happens to be open.
+      - run: pip install ruff==0.16.1 mypy==2.3.0
       - name: Self-check Python files
         run: |
+          # No `set -e` reliance: the runner aborts the loop on the first
+          # failure, which hid every problem after the first file.
+          rc=0
           for f in check.py fix.py install-hooks.py init-ci.py; do
             echo "--- $f ---"
-            python check.py "$f" --pretty
+            python check.py "$f" --pretty || rc=1
           done
+          exit $rc
 
   js:
     name: JS (eslint)

--- a/check.py
+++ b/check.py
@@ -13,12 +13,12 @@ Exit codes:
     2  — usage / tool-not-found error
 """
 
-import sys
-import os
+import argparse
 import json
+import os
 import shutil
 import subprocess
-import argparse
+import sys
 from pathlib import Path
 
 # Inject known tool locations that may not be on PATH yet (e.g. before reboot)
@@ -42,7 +42,7 @@ def run_ruff(target: str) -> dict:
         return _tool_missing("ruff")
     result = subprocess.run(
         ["ruff", "check", "--output-format", "json", target],
-        capture_output=True, text=True,
+        capture_output=True, text=True, check=False,
     )
     try:
         raw = json.loads(result.stdout) if result.stdout.strip() else []
@@ -69,7 +69,7 @@ def run_mypy(target: str) -> dict:
     result = subprocess.run(
         ["mypy", "--show-error-codes", "--no-error-summary",
          "--ignore-missing-imports", target],
-        capture_output=True, text=True,
+        capture_output=True, text=True, check=False,
     )
     issues = []
     for line in result.stdout.splitlines():
@@ -152,7 +152,7 @@ def run_eslint(target: str) -> dict:
         return _tool_missing("node (required for eslint)")
     if not runner.exists():
         return _tool_missing("jp_eslint.mjs")
-    result = subprocess.run([node, str(runner), target], capture_output=True, text=True,
+    result = subprocess.run([node, str(runner), target], capture_output=True, text=True, check=False,
                             cwd=str(tools_dir))
     issues = []
     try:
@@ -185,7 +185,7 @@ def run_stylelint(target: str) -> dict:
         return _tool_missing("node (required for stylelint)")
     if not runner.exists():
         return _tool_missing("jp_stylelint.mjs")
-    result = subprocess.run([node, str(runner), target], capture_output=True, text=True,
+    result = subprocess.run([node, str(runner), target], capture_output=True, text=True, check=False,
                             cwd=str(tools_dir))
     issues = []
     try:
@@ -246,7 +246,7 @@ def run_phpstan(target: str) -> dict:
     args = [php, bin_, "analyse", "--error-format=json", "--no-progress"]
     if cfg.exists():
         args += ["-c", str(cfg)]
-    result = subprocess.run(args + [target], capture_output=True, text=True)
+    result = subprocess.run(args + [target], capture_output=True, text=True, check=False)
     issues = []
     try:
         data = json.loads(result.stdout)
@@ -281,7 +281,7 @@ def run_phpcs(target: str) -> dict:
     args = [php, bin_, "--report=json"]
     if cfg.exists():
         args += [f"--standard={cfg}"]
-    result = subprocess.run(args + [target], capture_output=True, text=True)
+    result = subprocess.run(args + [target], capture_output=True, text=True, check=False)
     issues = []
     try:
         data = json.loads(result.stdout)
@@ -317,7 +317,7 @@ def run_rector(target: str) -> dict:
     args = [php, bin_, "process", "--dry-run", "--output-format=json", "--no-progress-bar"]
     if cfg.exists():
         args += [f"--config={cfg}"]
-    result = subprocess.run(args + [target], capture_output=True, text=True)
+    result = subprocess.run(args + [target], capture_output=True, text=True, check=False)
     issues = []
     try:
         data = json.loads(result.stdout)
@@ -343,7 +343,7 @@ def run_prettier(target: str) -> dict:
     cmd = shutil.which("prettier") or shutil.which("prettier.cmd")
     if not cmd:
         return _tool_missing("prettier")
-    result = subprocess.run([cmd, "--check", target], capture_output=True, text=True)
+    result = subprocess.run([cmd, "--check", target], capture_output=True, text=True, check=False)
     issues = []
     for line in (result.stdout + result.stderr).splitlines():
         line = line.strip()
@@ -381,7 +381,7 @@ def run_pip_audit(target: str) -> dict:
     args = [cmd, "--format", "json"]
     if req_file:
         args += ["-r", req_file]
-    result = subprocess.run(args, capture_output=True, text=True)
+    result = subprocess.run(args, capture_output=True, text=True, check=False)
     issues = []
     try:
         data = json.loads(result.stdout)
@@ -411,7 +411,7 @@ def run_npm_audit(target: str) -> dict:
     if not pkg_json.exists():
         return {"tool": "npm-audit", "status": "skip", "issues": [],
                 "note": "No package.json found"}
-    result = subprocess.run([cmd, "audit", "--json"], capture_output=True, text=True,
+    result = subprocess.run([cmd, "audit", "--json"], capture_output=True, text=True, check=False,
                             cwd=work_dir)
     issues = []
     try:
@@ -448,7 +448,7 @@ def run_composer_audit(target: str) -> dict:
         cmd = [php, composer or "composer", "audit", "--format=json"]
     else:
         cmd = [composer, "audit", "--format=json"]
-    result = subprocess.run(cmd, capture_output=True, text=True, cwd=work_dir)
+    result = subprocess.run(cmd, capture_output=True, text=True, check=False, cwd=work_dir)
     issues = []
     try:
         data = json.loads(result.stdout)
@@ -470,7 +470,7 @@ def run_composer_audit(target: str) -> dict:
 
 # ── helpers ───────────────────────────────────────────────────────────────────
 
-def _status(issues: list, returncode: int = None) -> str:
+def _status(issues: list, returncode: int | None = None) -> str:
     if returncode is not None and returncode not in (0, 1):
         return "error"
     return "fail" if issues else "pass"

--- a/fix.py
+++ b/fix.py
@@ -7,11 +7,11 @@ Usage:
     python fix.py <path> [--lang python|js|auto] [--dry-run] [--pretty]
 """
 
-import os
+import argparse
 import json
+import os
 import shutil
 import subprocess
-import argparse
 from pathlib import Path
 
 _EXTRA_PATHS = [
@@ -30,11 +30,11 @@ def fix_ruff(target: str, dry_run: bool) -> dict:
     args = ["ruff", "check", "--fix"]
     if dry_run:
         args.append("--diff")
-    subprocess.run(args + [target], capture_output=True, text=True)
+    subprocess.run(args + [target], capture_output=True, text=True, check=False)
     # After fix, re-check to find what remains
     recheck = subprocess.run(
         ["ruff", "check", "--output-format", "json", target],
-        capture_output=True, text=True,
+        capture_output=True, text=True, check=False,
     )
     try:
         remaining = json.loads(recheck.stdout) if recheck.stdout.strip() else []
@@ -62,14 +62,14 @@ def fix_prettier(target: str, dry_run: bool) -> dict:
     if not cmd:
         return {"tool": "prettier", "status": "unavailable", "fixed": 0, "remaining": []}
     if dry_run:
-        result = subprocess.run([cmd, "--check", target], capture_output=True, text=True)
+        result = subprocess.run([cmd, "--check", target], capture_output=True, text=True, check=False)
         unformatted = [
             line.strip()[len("[warn]"):].strip()
             for line in (result.stdout + result.stderr).splitlines()
             if line.strip().startswith("[warn]")
         ]
         return {"tool": "prettier", "status": "dry-run", "would_fix": unformatted}
-    result = subprocess.run([cmd, "--write", target], capture_output=True, text=True)
+    result = subprocess.run([cmd, "--write", target], capture_output=True, text=True, check=False)
     return {
         "tool":   "prettier",
         "status": "fixed" if result.returncode == 0 else "error",
@@ -107,7 +107,7 @@ def fix_phpcs(target: str, dry_run: bool) -> dict:
         check_bin = _php_bin("phpcs")
         if check_bin:
             r = subprocess.run([php, check_bin, "--report=json"] + ([f"--standard={cfg}"] if cfg.exists() else []) + [target],
-                               capture_output=True, text=True)
+                               capture_output=True, text=True, check=False)
             try:
                 data = json.loads(r.stdout)
                 fixable = [m for fd in data.get("files", {}).values()
@@ -117,7 +117,7 @@ def fix_phpcs(target: str, dry_run: bool) -> dict:
             except (json.JSONDecodeError, TypeError):
                 pass
         return {"tool": "phpcbf", "status": "dry-run", "would_fix": "?"}
-    result = subprocess.run(args + [target], capture_output=True, text=True)
+    result = subprocess.run(args + [target], capture_output=True, text=True, check=False)
     return {"tool": "phpcbf", "status": "fixed" if result.returncode in (0, 1) else "error",
             "output": result.stdout.strip()}
 
@@ -136,7 +136,7 @@ def fix_rector(target: str, dry_run: bool) -> dict:
         args += [f"--config={cfg}"]
     if dry_run:
         args.append("--dry-run")
-    result = subprocess.run(args + [target], capture_output=True, text=True)
+    result = subprocess.run(args + [target], capture_output=True, text=True, check=False)
     try:
         data = json.loads(result.stdout)
         changed = data.get("changed_files", [])

--- a/init-ci.py
+++ b/init-ci.py
@@ -7,9 +7,9 @@ Usage:
     python init-ci.py [path-to-repo]    # defaults to cwd
 """
 
-import sys
-import shutil
 import argparse
+import shutil
+import sys
 from pathlib import Path
 
 TEMPLATES_DIR = Path(__file__).resolve().parent / "templates"

--- a/install-hooks.py
+++ b/install-hooks.py
@@ -8,8 +8,8 @@ Usage:
     python install-hooks.py --remove [path]     # uninstall the hook
 """
 
-import sys
 import argparse
+import sys
 from pathlib import Path
 
 TOOLS_DIR = Path(__file__).resolve().parent

--- a/templates/ci-check.yml
+++ b/templates/ci-check.yml
@@ -39,7 +39,9 @@ jobs:
         include:
           - lang: python
             setup: |
-              pip install ruff mypy pip-audit
+              # Pin these. Unpinned linters turn a green build red without any
+              # code change, months later, in whichever PR happens to be open.
+              pip install ruff==0.16.1 mypy==2.3.0 pip-audit==2.10.1
           - lang: js
             setup: |
               npm install -g eslint prettier


### PR DESCRIPTION
The Python check has been red since 2026-08-05 against code last touched in April.

`check.py` is **byte-identical to the last green build** (e1b8151, 9 April), so nothing here changed — `pip install ruff mypy` is unpinned, and four months of releases added rules while the source stood still. Reproduced exactly with ruff 0.16.1: same 14 errors, same lines.

## Pinned

`ruff==0.16.1 mypy==2.3.0` in the workflow, and `ruff==0.16.1 mypy==2.3.0 pip-audit==2.10.1` in `templates/ci-check.yml`.

**The template matters more than the workflow** — `init-ci.py` copies it into other repos, so every project initialised from here carried the same delayed fault.

## Fixed 27 violations, not the 14 CI reported

The loop runs under the runner's `bash -e` and aborted on the first file, so `check.py`'s errors hid everything in `fix.py`, `install-hooks.py` and `init-ci.py`. The loop now records the failure and continues, then exits non-zero, so one bad file no longer masks the rest.

| rule | count | fix |
|---|---|---|
| `PLW1510` | 18 | `subprocess.run` without explicit `check` — added `check=False` |
| `I001` | 4 | unsorted imports |
| `EXE001` | 4 | shebang without the executable bit |
| `RUF013` | 1 | implicit `Optional` → `int \| None` |

`check=False` is already `subprocess.run`'s default, so it documents existing behaviour rather than changing it. Every one of those calls inspects `returncode` or parses `stdout` itself — raising on non-zero would break them, since a linter finding problems exits non-zero by design.

Also worth noting: **`check.py` reported "13 fixable" where ruff reports 1.** It counts `fix is not None`, which includes unsafe fixes; only the import sort is a safe automatic fix.

## Deliberately not in this PR

- **`check.py` passes no `--config` to ruff or mypy**, so `configs/ruff.toml` and `configs/mypy.ini` ship but are never used — these runs are on ruff's defaults. Config discovery is implemented for phpstan, phpcs and rector only. Wiring it up would change which rules apply repo-wide and deserves its own change.
- **CI lints only those four files.** The recovery tools, `chd.py`, `recover.py`, `undelete.py` and the rest are checked by nothing.

## Verification

ruff 0.16.1 verified locally — all four files pass. **mypy could not be verified locally** (no pip on this machine), so that half is pinned but unproven until CI runs here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)