### PR TITLE
Make the private iteration8/utilities dependency optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,21 @@ bash install-recovery.sh
 powershell install-recovery.ps1
 ```
 
+### Optional: find-dupes.php
+
+`find-dupes.php` is the one tool that needs `iteration8/utilities`, a private library.
+It is deliberately **not** in `composer.json` so that `composer install` works for everyone;
+skip this section and every other tool still runs.
+
+If you have access to the repo:
+
+```bash
+composer config repositories.iteration8-utilities vcs https://github.com/jparish1977/iteration8-utilities.git
+composer require iteration8/utilities:dev-master
+```
+
+That edits your local `composer.json` — don't commit those two entries back.
+
 ## Tools
 
 ### Code Quality
@@ -41,6 +56,9 @@ powershell install-recovery.ps1
 | `find-dupes.php` | Find duplicate files or compare directories |
 | | Pluggable hashers, caches (memory, filesystem, SQLite), output formats |
 | | Worker pool for parallel hashing, persistent hash DB for instant re-scans |
+
+`find-dupes.php` depends on `iteration8/utilities`, which lives in a private repo — see
+[Optional: find-dupes.php](#optional-find-dupesphp). Nothing else in JP_TOOLS needs it.
 
 ### Data Recovery (Python)
 

--- a/composer.json
+++ b/composer.json
@@ -1,9 +1,6 @@
 {
     "name": "jp-tools/php-quality",
     "description": "PHP code quality tools for JP_TOOLS",
-    "require": {
-        "iteration8/utilities": "dev-master"
-    },
     "require-dev": {
         "nikic/php-parser": "^5.0",
         "phpstan/phpstan": "^2.0",
@@ -11,18 +8,9 @@
         "rector/rector": "^2.0",
         "squizlabs/php_codesniffer": "^3.10"
     },
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "https://github.com/jparish1977/iteration8-utilities.git"
-        },
-        {
-            "type": "vcs",
-            "url": "https://github.com/jparish1977/iteration8-core.git"
-        }
-    ],
-    "minimum-stability": "dev",
-    "prefer-stable": true,
+    "suggest": {
+        "iteration8/utilities": "Required by find-dupes.php only. Private repo — see README (Optional: find-dupes.php)."
+    },
     "config": {
         "optimize-autoloader": true,
         "sort-packages": true

--- a/find-dupes.php
+++ b/find-dupes.php
@@ -22,7 +22,12 @@ declare(strict_types=1);
 
 ini_set('memory_limit', '1G');
 
-require_once __DIR__ . '/vendor/autoload.php';
+$autoload = __DIR__ . '/vendor/autoload.php';
+if (!is_file($autoload)) {
+    fwrite(STDERR, "vendor/autoload.php missing — run: composer install\n");
+    exit(1);
+}
+require_once $autoload;
 
 use Iteration8\Utilities\FileScanner\Cache\FilesystemCache;
 use Iteration8\Utilities\FileScanner\Cache\MemoryCache;
@@ -33,6 +38,19 @@ use Iteration8\Utilities\FileScanner\Hasher\NativeHasher;
 use Iteration8\Utilities\FileScanner\Output\ConsoleOutput;
 use Iteration8\Utilities\FileScanner\Output\JsonOutput;
 use Iteration8\Utilities\FileScanner\Scanner;
+
+if (!class_exists(Scanner::class)) {
+    fwrite(STDERR, <<<'TXT'
+        find-dupes.php needs the iteration8/utilities library, which lives in a private repo.
+        Every other JP_TOOLS tool works without it.
+
+        If you have access, add it with:
+          composer config repositories.iteration8-utilities vcs https://github.com/jparish1977/iteration8-utilities.git
+          composer require iteration8/utilities:dev-master
+
+        TXT);
+    exit(1);
+}
 
 // --- Parse arguments ---
 $args = $argv;


### PR DESCRIPTION
`composer install` fails for anyone without access to the private `iteration8` repos:

```
In CurlDownloader.php line 686:
The "https://api.github.com/repos/jparish1977/iteration8-utilities" file could not be downloaded (HTTP/2 404)
{"message":"Not Found", ...}
```

`composer.json` declared `jparish1977/iteration8-utilities` and `iteration8-core` as VCS repositories. Both are private, and Composer probes VCS repositories eagerly at install time, so GitHub's 404-for-unauthorized aborts the entire install — including phpstan, phpcs and rector, which are public packages `check.py` depends on. The result is that an outside collaborator gets none of the PHP tooling.

`find-dupes.php` is the only tool that uses the library.

## Changes

- **composer.json** — drop both private VCS repositories and the `iteration8/utilities` require; demote to `suggest`. Also drop `minimum-stability: dev` / `prefer-stable`, which only existed to allow `dev-master` of that package and would otherwise let Composer resolve dev builds of the linters.
- **find-dupes.php** — report a missing `vendor/` or missing library with the opt-in instructions instead of dying on a fatal.
- **README.md** — new "Optional: find-dupes.php" section with the `composer config` / `composer require` commands for anyone who does have access.

## Testing

`php -l` clean. Both new guard paths exercised — no `vendor/` reports `run: composer install`; a `vendor/` without the library prints the opt-in commands. Composer isn't installed locally, so `composer install` itself was not run; `composer.json` was validated as JSON only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)