### PR TITLE
Ignore Python cache directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ node_modules/
 package-lock.json
 vendor/
 composer.lock
+__pycache__/
+.mypy_cache/
+.ruff_cache/


### PR DESCRIPTION
Running any of the Python tools in this repo leaves `__pycache__/` behind. It is not ignored, so it shows as untracked in every `git status`, and it is noise for anyone picking the toolbox up. `.mypy_cache/` and `.ruff_cache/` are the same story.

Worth doing beyond tidiness: the identical problem bit `claude-config` on iteration8 today. A tracked `.pyc` kept the working tree permanently dirty, so the scheduled `git pull --rebase` aborted with `cannot pull with rebase: Your index contains uncommitted changes`, and that machine sat 17 commits behind without anything reporting it. The weekly job running there would have graded a stale corpus.

Ignoring the caches here removes the same failure mode before it can happen.