### PR TITLE
Make the quality gate mean what it says

### DIFF
--- a/check.py
+++ b/check.py
@@ -37,11 +37,27 @@ os.environ["PYTHONUTF8"] = "1"
 
 # ── tool runners ──────────────────────────────────────────────────────────────
 
+def _ruff_config_args(target: str) -> list[str]:
+    """Point ruff at the JP_TOOLS defaults, unless the project has its own.
+
+    ruff already implements precedence when it discovers a config itself, so
+    passing --config on top of a project's own file would override the project
+    rather than defer to it. Supply the default only when there is nothing to
+    discover. Note a bare pyproject.toml counts: --config would fail on one
+    with no [tool.ruff] section, and ruff handles that case correctly alone.
+    """
+    if _find_project_config(target, ["ruff.toml", ".ruff.toml", "pyproject.toml"]):
+        return []
+    shared = Path(__file__).parent / "configs" / "ruff.toml"
+    return ["--config", str(shared)] if shared.exists() else []
+
+
 def run_ruff(target: str) -> dict:
     if not shutil.which("ruff"):
         return _tool_missing("ruff")
     result = subprocess.run(
-        ["ruff", "check", "--output-format", "json", target],
+        ["ruff", "check", *_ruff_config_args(target),
+         "--output-format", "json", target],
         capture_output=True, text=True, check=False,
     )
     try:
@@ -56,7 +72,14 @@ def run_ruff(target: str) -> dict:
             "severity": "error",
             "rule":     i.get("code", ""),
             "message":  i.get("message", ""),
-            "fixable":  i.get("fix") is not None,
+            # "fixable" means fix.py can apply it as invoked by default, which
+            # is `ruff check --fix`: safe fixes only. Counting every finding
+            # that carries a fix object overstated it badly -- on recover.py,
+            # 14 of 18 carried one while only 2 were safe, the rest being 3
+            # unsafe and 9 displayonly, which are never auto-applied at all.
+            "fixable":  (i.get("fix") or {}).get("applicability") == "safe",
+            "fixable_unsafe":
+                (i.get("fix") or {}).get("applicability") == "unsafe",
         }
         for i in raw
     ]
@@ -246,7 +269,7 @@ def run_phpstan(target: str) -> dict:
     args = [php, bin_, "analyse", "--error-format=json", "--no-progress"]
     if cfg.exists():
         args += ["-c", str(cfg)]
-    result = subprocess.run(args + [target], capture_output=True, text=True, check=False)
+    result = subprocess.run([*args, target], capture_output=True, text=True, check=False)
     issues = []
     try:
         data = json.loads(result.stdout)
@@ -281,7 +304,7 @@ def run_phpcs(target: str) -> dict:
     args = [php, bin_, "--report=json"]
     if cfg.exists():
         args += [f"--standard={cfg}"]
-    result = subprocess.run(args + [target], capture_output=True, text=True, check=False)
+    result = subprocess.run([*args, target], capture_output=True, text=True, check=False)
     issues = []
     try:
         data = json.loads(result.stdout)
@@ -317,7 +340,7 @@ def run_rector(target: str) -> dict:
     args = [php, bin_, "process", "--dry-run", "--output-format=json", "--no-progress-bar"]
     if cfg.exists():
         args += [f"--config={cfg}"]
-    result = subprocess.run(args + [target], capture_output=True, text=True, check=False)
+    result = subprocess.run([*args, target], capture_output=True, text=True, check=False)
     issues = []
     try:
         data = json.loads(result.stdout)
@@ -570,7 +593,11 @@ def _summarize(checks: list[dict]) -> dict:
         "total":    len(all_issues),
         "errors":   errors,
         "warnings": warnings,
+        # Split deliberately: "fixable" is what `fix.py` applies now, and
+        # "fixable_unsafe" is what `fix.py --unsafe` would additionally attempt.
+        # Reporting one combined number described work no tool would do.
         "fixable":  sum(1 for i in all_issues if i.get("fixable")),
+        "fixable_unsafe": sum(1 for i in all_issues if i.get("fixable_unsafe")),
     }
 
 

--- a/configs/ruff.toml
+++ b/configs/ruff.toml
@@ -3,7 +3,10 @@
 # Or copy/symlink into a project as ruff.toml
 
 line-length = 100
-target-version = "py38"
+# Matches the CI runner (3.12). This said py38, which was wrong in a way
+# nothing could catch while the file went unused: check.py itself uses
+# `str | None`, which needs 3.10.
+target-version = "py312"
 
 [lint]
 select = [

--- a/configs/ruff.toml
+++ b/configs/ruff.toml
@@ -20,12 +20,21 @@ select = [
     "C4",   # flake8-comprehensions
     "SIM",  # flake8-simplify
     "RUF",  # ruff-specific
+
+    # Chosen against what this codebase actually does, rather than inherited
+    # from whatever the installed ruff defaults to. Widened 2026-08-12 after
+    # measuring what the narrower list was dropping.
+    "DTZ",      # naive datetime — inventories and logs record mtimes
+    "EXE",      # shebang/executable-bit agreement — this repo is scripts
+    "ISC",      # implicit string concatenation
+    "BLE",      # blind except
+    "PLW1510",  # subprocess.run without an explicit check=
+    "S110",     # try/except/pass, which swallows the error entirely
 ]
 ignore = [
     "E501",   # line too long — handled by formatter, not linter
     "B008",   # do not perform function calls in default arguments (common in Tkinter/UI)
     "SIM108", # ternary operator — sometimes less readable
-    "UP007",  # use X | Y for union types — requires Python 3.10+
 ]
 
 [lint.per-file-ignores]

--- a/fix.py
+++ b/fix.py
@@ -14,6 +14,11 @@ import shutil
 import subprocess
 from pathlib import Path
 
+# One definition of where ruff's config comes from. check.py is import-safe
+# (its argparse sits behind a main guard), so this defers to it rather than
+# keeping a second copy that can drift out of step.
+from check import _ruff_config_args
+
 _EXTRA_PATHS = [
     Path(os.environ.get("APPDATA", "")) / "npm",
     Path("C:/Program Files/nodejs"),
@@ -24,16 +29,41 @@ os.environ["PATH"] = os.pathsep.join(
 )
 
 
-def fix_ruff(target: str, dry_run: bool) -> dict:
+
+def _ruff_count(target: str) -> int:
+    """How many diagnostics ruff reports right now."""
+    out = subprocess.run(
+        ["ruff", "check", *_ruff_config_args(target), "--output-format", "json", target],
+        capture_output=True, text=True, check=False,
+    ).stdout
+    try:
+        return len(json.loads(out)) if out.strip() else 0
+    except json.JSONDecodeError:
+        return 0
+
+
+def fix_ruff(target: str, dry_run: bool, unsafe: bool = False, **_: object) -> dict:
+    """Apply ruff's fixes.
+
+    `ruff check --fix` applies *safe* fixes only. Most of what accumulates in
+    practice is classed unsafe (a rewrite that could change behaviour, such as
+    percent-format to f-string) or displayonly (never auto-applied). Without
+    --unsafe this reports 0 fixed on files check.py describes as fixable, which
+    is the tool disagreeing with its own report rather than a no-op.
+    """
     if not shutil.which("ruff"):
         return {"tool": "ruff", "status": "unavailable", "fixed": 0, "remaining": []}
-    args = ["ruff", "check", "--fix"]
+    before = _ruff_count(target)
+    args = ["ruff", "check", *_ruff_config_args(target), "--fix"]
+    if unsafe:
+        args.append("--unsafe-fixes")
     if dry_run:
         args.append("--diff")
-    subprocess.run(args + [target], capture_output=True, text=True, check=False)
+    subprocess.run([*args, target], capture_output=True, text=True, check=False)
     # After fix, re-check to find what remains
     recheck = subprocess.run(
-        ["ruff", "check", "--output-format", "json", target],
+        ["ruff", "check", *_ruff_config_args(target),
+         "--output-format", "json", target],
         capture_output=True, text=True, check=False,
     )
     try:
@@ -43,7 +73,9 @@ def fix_ruff(target: str, dry_run: bool) -> dict:
     return {
         "tool":      "ruff",
         "status":    "dry-run" if dry_run else "fixed",
-        "fixed":     "?" if dry_run else "auto",
+        # A real number. This used to say "auto", which was not checkable.
+        "fixed":     0 if dry_run else max(0, before - len(remaining)),
+        "unsafe":    unsafe,
         "remaining": [
             {"file": i.get("filename"), "line": i.get("location", {}).get("row"),
              "rule": i.get("code"), "message": i.get("message")}
@@ -52,7 +84,7 @@ def fix_ruff(target: str, dry_run: bool) -> dict:
     }
 
 
-def fix_prettier(target: str, dry_run: bool) -> dict:
+def fix_prettier(target: str, dry_run: bool, **_: object) -> dict:
     local_bin = Path(__file__).parent / "node_modules" / ".bin"
     cmd = (
         str(local_bin / "prettier.cmd") if (local_bin / "prettier.cmd").exists() else
@@ -90,7 +122,7 @@ def _php_cmd() -> str | None:
     return shutil.which("php") or shutil.which("php.exe")
 
 
-def fix_phpcs(target: str, dry_run: bool) -> dict:
+def fix_phpcs(target: str, dry_run: bool, **_: object) -> dict:
     php  = _php_cmd()
     bin_ = _php_bin("phpcbf")
     if not php:
@@ -117,12 +149,12 @@ def fix_phpcs(target: str, dry_run: bool) -> dict:
             except (json.JSONDecodeError, TypeError):
                 pass
         return {"tool": "phpcbf", "status": "dry-run", "would_fix": "?"}
-    result = subprocess.run(args + [target], capture_output=True, text=True, check=False)
+    result = subprocess.run([*args, target], capture_output=True, text=True, check=False)
     return {"tool": "phpcbf", "status": "fixed" if result.returncode in (0, 1) else "error",
             "output": result.stdout.strip()}
 
 
-def fix_rector(target: str, dry_run: bool) -> dict:
+def fix_rector(target: str, dry_run: bool, **_: object) -> dict:
     php  = _php_cmd()
     bin_ = _php_bin("rector")
     if not php:
@@ -136,7 +168,7 @@ def fix_rector(target: str, dry_run: bool) -> dict:
         args += [f"--config={cfg}"]
     if dry_run:
         args.append("--dry-run")
-    result = subprocess.run(args + [target], capture_output=True, text=True, check=False)
+    result = subprocess.run([*args, target], capture_output=True, text=True, check=False)
     try:
         data = json.loads(result.stdout)
         changed = data.get("changed_files", [])
@@ -183,6 +215,9 @@ def main():
     parser.add_argument("--lang",    choices=["python", "js", "css", "php", "auto"], default="auto")
     parser.add_argument("--dry-run", action="store_true",
                         help="Show what would change without writing files")
+    parser.add_argument("--unsafe",  action="store_true",
+                        help="also apply ruff's unsafe fixes; these can change "
+                             "behaviour, so review the diff")
     parser.add_argument("--pretty",  action="store_true")
     args = parser.parse_args()
 
@@ -190,7 +225,7 @@ def main():
     lang   = args.lang if args.lang != "auto" else _detect_lang(target)
     fixers = FIXERS.get(lang, [])
 
-    results = [fn(target, args.dry_run) for _, fn in fixers]
+    results = [fn(target, args.dry_run, unsafe=args.unsafe) for _, fn in fixers]
     print(json.dumps({"target": target, "language": lang, "results": results},
                      indent=2 if args.pretty else None))
 


### PR DESCRIPTION
Two defects, both found by trying to use the toolbox on itself.

## `fix.py` could not apply what `check.py` called fixable

`check.py` counted any finding carrying a `fix` object as fixable. `fix.py` runs `ruff check --fix`, which applies **safe** fixes only. On `recover.py` that read **14 fixable when `fix.py` could apply 2** — the rest were 3 unsafe and 9 `displayonly`, and displayonly is never auto-applied by anything.

The practical symptom: asked to clean four files carrying 35 findings, `fix.py` changed nothing, while `check.py` kept reporting them as fixable.

- `check.py` now splits the count into **`fixable`** (what `fix.py` applies now) and **`fixable_unsafe`** (what `--unsafe` would additionally attempt).
- `fix.py` grows **`--unsafe`**, and reports a real number instead of the string `"auto"`, which nobody could check.

Demonstrated on `recover.py`:

```
check.py   ->  total 5, fixable 2, fixable_unsafe 3
fix.py     ->  fixed 2
fix.py --unsafe -> fixed 3 more
```

## `configs/ruff.toml` was never used

Nothing passed `--config`, and there is no root-level config to discover, so the documented shared config had no effect on any run. Its own header says "Applied when running: `ruff check --config ...`" and nothing did.

Both tools now pass it, and **only when the project has none of its own** — ruff already implements precedence correctly when it discovers a config itself. A bare `pyproject.toml` counts as the project's own, since `--config` fails on one with no `[tool.ruff]` section.

### The list in it had never been validated

Because nothing had ever used the config, nothing had ever tested whether its rule list suited the codebase. It did not. Measured against the repo, the narrow list dropped exactly the findings that matter for a toolbox built on subprocess calls and error handling:

```
33  PLW1510  subprocess.run with no explicit check=
13  EXE001   shebang present, executable bit missing
13  DTZ005   naive datetime, in tools that record mtimes
 4  ISC004   implicit string concatenation
 3  BLE001   blind except
 2  S110     try/except/pass, swallowing the error entirely
```

`BLE001` and `S110` are the same silent-failure class as the NTFS bug fixed in #15, where an empty file was quietly never copied. `PLW1510` is that idea one level down: a tool shelling out to `ddrescue`, `photorec` and `ntfscat` should say out loud when it does not care whether the command succeeded. For most of those the fix is not `check=True` — it is writing `check=False` on purpose, so a tolerated failure is visible rather than assumed.

So the select list is widened to match. Repo-wide **38 → 106**. Deliberately *not* adding `PL` or `S` wholesale, which measure 160 and 230: a gate that reports mostly noise stops being read, then gets blanket-`noqa`'d, and then it is decorative.

**All four CI-gated files stay clean under the wider set** — they already pass `check=` explicitly and their exec bits are right — so the gate gets stronger without breaking what it guards.

Also drops the `UP007` ignore, whose stated reason was "requires Python 3.10+". `target-version` is `py312` now, so that no longer holds.

The config also declared `target-version = "py38"` while `check.py` uses `str | None` (needs 3.10) and CI runs 3.12. Corrected — no change to the counts, but it was wrong in a way nothing could catch while the file went unused.

## Notes

- `fix.py` imports the resolver from `check.py` rather than keeping a second copy, so the two cannot drift.
- All four CI-gated files are clean under the new wiring, and the tools fixed themselves: the `RUF005` findings this surfaced in `check.py` and `fix.py` were cleared with `fix.py --unsafe`.
- Not addressed here, filed for the follow-up: **CI checks only 4 of 21 Python files**, which is why 100+ findings accumulated unseen.
