### PR TITLE
Say what the installer installed, and drop "shape"

### DIFF
--- a/METHODOLOGY.md
+++ b/METHODOLOGY.md
@@ -315,7 +315,7 @@ of them because they treated adoption as an event rather than a rate.
    cross-imports settles whether piecemeal is cheap or a fantasy. In
    batocera-watch, 31 scripts held **three** internal edges between them, which
    made extraction close to free; both plans drawn before that measurement had
-   assumed it would be expensive and were shaped around avoiding a cost that
+   assumed it would be expensive and were built around avoiding a cost that
    did not exist. Measure the coupling first. It is the input that decides the
    entire strategy, and it takes one command.
 

--- a/install-hooks.py
+++ b/install-hooks.py
@@ -120,7 +120,7 @@ def install(repo_path: Path):
     # Make executable (matters on Linux/Mac, no-op on Windows)
     hook_file.chmod(0o755)
     print(f"Installed JP_TOOLS pre-commit hook at {hook_file}")
-    print(f"Checks will run: python {CHECK_PY} .")
+    print(f"Checks will run: {CHECK_PY} against each staged file")
     print()
     print("This project now follows JP_TOOLS methodology.")
     print(f"Read it: {METHODOLOGY_DOC}")

--- a/tests/test_install_hooks.py
+++ b/tests/test_install_hooks.py
@@ -85,8 +85,13 @@ def commit_file(repo: Path, name: str, body: str) -> subprocess.CompletedProcess
     return git(repo, "commit", "-m", f"add {name}")
 
 
-def build_repo(tmp: Path) -> Path:
-    """A repo carrying pre-existing debt, with the hook installed over it."""
+def build_repo(tmp: Path) -> tuple[Path, str]:
+    """A repo carrying pre-existing debt, with the hook installed over it.
+
+    Returns the repo and the installer's stdout, because what the installer
+    SAYS it set up is a separate claim from what it wrote, and the two drifted
+    apart once already.
+    """
     repo = tmp / "repo"
     repo.mkdir()
     git(repo, "init", "-q")
@@ -103,7 +108,7 @@ def build_repo(tmp: Path) -> Path:
     )
     if install.returncode != 0:
         raise RuntimeError(f"install-hooks.py failed: {install.stderr}")
-    return repo
+    return repo, install.stdout
 
 
 def main() -> int:
@@ -124,11 +129,17 @@ def main() -> int:
 
     with tempfile.TemporaryDirectory() as td:
         tmp = Path(td)
-        repo = build_repo(tmp)
+        repo, install_out = build_repo(tmp)
 
         hook = repo / ".git" / "hooks" / "pre-commit"
         check("hook installed", hook.is_file())
         check("hook is executable", os.access(hook, os.X_OK))
+        # The installer announced "python check.py ." for one commit after the
+        # hook stopped doing that. Same defect as the original: a description
+        # that outlived the behaviour it described.
+        check("installer describes what it installed",
+              "staged" in install_out and "check.py ." not in install_out,
+              install_out)
 
         print("\nAgainst a repo that already fails:")
 


### PR DESCRIPTION
`install-hooks.py` printed `Checks will run: python <check.py> .` while the hook two lines below iterated staged files. Same defect #25 fixed, in the same file: a description that outlived the behaviour.

Found by installing into batocera-watch and reading the output. Nothing in the suite looked at what the installer *says*, only at what it writes, so the two were free to disagree. `build_repo` now returns the installer's stdout and the suite asserts on it. Restoring the old line gives 11/12, so the assertion works.

Also one prose fix in METHODOLOGY.md, `shaped around` to `built around`, per the standing rule against "the shape of X" phrasing.