### PR TITLE
Make the gate enforce the bar the manual claims

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -31,6 +31,12 @@ jobs:
             python check.py "$f" --pretty || rc=1
           done
           exit $rc
+      # The PHP tools live in vendor/, so without this every phpstan assertion
+      # in tests/ skips, and a skip is indistinguishable from a pass in the log.
+      # test_check_phpstan.py pins a bug that reported the repo directory as
+      # the filename for every finding; it is worth nothing if it never runs.
+      - name: Install PHP tools
+        run: composer install --no-interaction --no-progress
       - name: Run test suites
         run: |
           # Nothing ran tests/ at all before this step existed, so a suite

--- a/check.py
+++ b/check.py
@@ -21,6 +21,7 @@ import shutil
 import subprocess
 import sys
 from pathlib import Path
+from typing import Any
 
 # Inject known tool locations that may not be on PATH yet (e.g. before reboot)
 _EXTRA_PATHS = [
@@ -53,7 +54,7 @@ def _ruff_config_args(target: str) -> list[str]:
     return ["--config", str(shared)] if shared.exists() else []
 
 
-def run_ruff(target: str) -> dict:
+def run_ruff(target: str) -> dict[str, Any]:
     if not shutil.which("ruff"):
         return _tool_missing("ruff")
     result = subprocess.run(
@@ -99,12 +100,27 @@ _MYPY_LINE = re.compile(
 )
 
 
-def run_mypy(target: str) -> dict:
+def _mypy_config_args(target: str) -> list[str]:
+    """Point mypy at the JP_TOOLS defaults, unless the project has its own.
+
+    Nothing passed this before, so configs/mypy.ini was dead file and the gate
+    ran on mypy's defaults while README described the file and METHODOLOGY
+    described something stricter than either. Project-local config wins, same
+    precedence as _ruff_config_args.
+    """
+    if _find_project_config(target, ["mypy.ini", ".mypy.ini", "setup.cfg",
+                                     "pyproject.toml"]):
+        return []
+    shared = Path(__file__).parent / "configs" / "mypy.ini"
+    return ["--config-file", str(shared)] if shared.exists() else []
+
+
+def run_mypy(target: str) -> dict[str, Any]:
     if not shutil.which("mypy"):
         return _tool_missing("mypy")
     result = subprocess.run(
         ["mypy", "--show-error-codes", "--no-error-summary",
-         "--ignore-missing-imports", target],
+         "--ignore-missing-imports", *_mypy_config_args(target), target],
         capture_output=True, text=True, check=False,
     )
     issues = []
@@ -134,7 +150,7 @@ def run_mypy(target: str) -> dict:
     return {"tool": "mypy", "status": _status(issues, result.returncode), "issues": issues}
 
 
-def _count_eslint_suppressions(target: str) -> list[dict]:
+def _count_eslint_suppressions(target: str) -> list[dict[str, Any]]:
     """Scan source files for eslint-disable comments — these are acknowledged but not invisible."""
     import re
     suppressions = []
@@ -169,7 +185,7 @@ def _count_eslint_suppressions(target: str) -> list[dict]:
     return suppressions
 
 
-def run_eslint(target: str) -> dict:
+def run_eslint(target: str) -> dict[str, Any]:
     tools_dir = Path(__file__).parent
     runner    = tools_dir / "jp_eslint.mjs"
     node      = shutil.which("node") or shutil.which("node.exe")
@@ -202,7 +218,7 @@ def run_eslint(target: str) -> dict:
     return {"tool": "eslint", "status": _status(issues), "issues": issues}
 
 
-def run_stylelint(target: str) -> dict:
+def run_stylelint(target: str) -> dict[str, Any]:
     tools_dir = Path(__file__).parent
     runner    = tools_dir / "jp_stylelint.mjs"
     node      = shutil.which("node") or shutil.which("node.exe")
@@ -258,7 +274,7 @@ def _find_project_config(target: str, filenames: list[str]) -> Path | None:
     return None
 
 
-def run_phpstan(target: str) -> dict:
+def run_phpstan(target: str) -> dict[str, Any]:
     php  = _php_cmd()
     bin_ = _php_bin("phpstan")
     if not php:
@@ -275,10 +291,14 @@ def run_phpstan(target: str) -> dict:
     issues = []
     try:
         data = json.loads(result.stdout)
-        for fe in data.get("files", {}).values():
+        # .items(), not .values(): phpstan keys this dict BY FILENAME and its
+        # message objects carry no "file" field, so iterating values discarded
+        # the only copy of the path and every finding fell back to `target`.
+        # A whole run then reported "<repo dir>:214" and named nothing.
+        for path, fe in data.get("files", {}).items():
             for msg in fe.get("messages", []):
                 issues.append({
-                    "file":     msg.get("file", target),
+                    "file":     msg.get("file", path),
                     "line":     msg.get("line", 0),
                     "col":      0,
                     "severity": "error",
@@ -293,7 +313,7 @@ def run_phpstan(target: str) -> dict:
     return {"tool": "phpstan", "status": _status(issues), "issues": issues}
 
 
-def run_phpcs(target: str) -> dict:
+def run_phpcs(target: str) -> dict[str, Any]:
     php  = _php_cmd()
     bin_ = _php_bin("phpcs")
     if not php:
@@ -328,7 +348,7 @@ def run_phpcs(target: str) -> dict:
     return {"tool": "phpcs", "status": _status(issues), "issues": issues}
 
 
-def run_rector(target: str) -> dict:
+def run_rector(target: str) -> dict[str, Any]:
     """Rector in dry-run mode — reports what would change without writing."""
     php  = _php_cmd()
     bin_ = _php_bin("rector")
@@ -364,7 +384,7 @@ def run_rector(target: str) -> dict:
     return {"tool": "rector", "status": _status(issues), "issues": issues}
 
 
-def run_prettier(target: str) -> dict:
+def run_prettier(target: str) -> dict[str, Any]:
     cmd = shutil.which("prettier") or shutil.which("prettier.cmd")
     if not cmd:
         return _tool_missing("prettier")
@@ -388,7 +408,7 @@ def run_prettier(target: str) -> dict:
 
 # ── security audit runners ────────────────────────────────────────────────────
 
-def run_pip_audit(target: str) -> dict:
+def run_pip_audit(target: str) -> dict[str, Any]:
     cmd = shutil.which("pip-audit") or shutil.which("pip-audit.exe")
     if not cmd:
         return _tool_missing("pip-audit (pip install pip-audit)")
@@ -426,7 +446,7 @@ def run_pip_audit(target: str) -> dict:
     return {"tool": "pip-audit", "status": _status(issues), "issues": issues}
 
 
-def run_npm_audit(target: str) -> dict:
+def run_npm_audit(target: str) -> dict[str, Any]:
     cmd = shutil.which("npm") or shutil.which("npm.cmd")
     if not cmd:
         return _tool_missing("npm")
@@ -456,7 +476,7 @@ def run_npm_audit(target: str) -> dict:
     return {"tool": "npm-audit", "status": _status(issues), "issues": issues}
 
 
-def run_composer_audit(target: str) -> dict:
+def run_composer_audit(target: str) -> dict[str, Any]:
     php = _php_cmd()
     composer = shutil.which("composer") or shutil.which("composer.bat")
     if not php and not composer:
@@ -500,13 +520,13 @@ def run_composer_audit(target: str) -> dict:
 
 # ── helpers ───────────────────────────────────────────────────────────────────
 
-def _status(issues: list, returncode: int | None = None) -> str:
+def _status(issues: list[dict[str, Any]], returncode: int | None = None) -> str:
     if returncode is not None and returncode not in (0, 1):
         return "error"
     return "fail" if issues else "pass"
 
 
-def _tool_missing(name: str) -> dict:
+def _tool_missing(name: str) -> dict[str, Any]:
     return {
         "tool":   name,
         "status": "unavailable",
@@ -595,7 +615,7 @@ _CPPCHECK_SUPPRESS = [
 ]
 
 
-def run_cppcheck(target: str) -> dict:
+def run_cppcheck(target: str) -> dict[str, Any]:
     """Static analysis for C/C++ and Arduino sketches.
 
     This is the linter slot, not the strongest check available. For firmware the
@@ -679,7 +699,7 @@ _DIR_CAPABLE = {"ruff", "mypy", "phpstan", "phpcs", "rector",
 # per file, and passing a directory would apply sketch rules to every .cpp.
 
 
-def _run_tools(tool_names: list[str], target: str) -> list[dict]:
+def _run_tools(tool_names: list[str], target: str) -> list[dict[str, Any]]:
     checks = []
     for name in tool_names:
         runner = TOOL_RUNNERS.get(name)
@@ -691,7 +711,7 @@ def _run_tools(tool_names: list[str], target: str) -> list[dict]:
     return checks
 
 
-def _summarize(checks: list[dict]) -> dict:
+def _summarize(checks: list[dict[str, Any]]) -> dict[str, Any]:
     all_issues = [i for c in checks for i in c.get("issues", [])]
     errors   = sum(1 for i in all_issues if i["severity"] == "error")
     warnings = sum(1 for i in all_issues if i["severity"] == "warning")
@@ -709,7 +729,7 @@ def _summarize(checks: list[dict]) -> dict:
 
 # ── main ──────────────────────────────────────────────────────────────────────
 
-def main():
+def main() -> None:
     parser = argparse.ArgumentParser(
         description="Run code quality tools and output structured JSON.",
     )
@@ -755,14 +775,18 @@ def main():
             tool_names.extend(AUDIT_TOOLS.get(lang, []))
 
         checks = _run_tools(tool_names, target)
+        # Held in its own name rather than read back out of `output`: the dict
+        # is heterogeneous, so indexing it twice asks the type checker to
+        # believe a str and a list are also subscriptable by "errors".
+        summary = _summarize(checks)
         output = {
             "target":   target,
             "language": lang,
             "checks":   checks,
-            "summary":  _summarize(checks),
+            "summary":  summary,
         }
         print(json.dumps(output, indent=2 if args.pretty else None))
-        sys.exit(1 if output["summary"]["errors"] > 0 else 0)
+        sys.exit(1 if summary["errors"] > 0 else 0)
 
     # ── Directory: scan, group by language, run appropriate tools ─────────
     groups, skipped = _collect_files(target)
@@ -810,6 +834,7 @@ def main():
             "tools":      [c["tool"] for c in lang_checks],
         })
 
+    summary = _summarize(all_checks)
     output = {
         "target":     target,
         "mode":       "multi-language",
@@ -819,11 +844,11 @@ def main():
         "skipped":    [{"extension": e, "file_count": n}
                        for e, n in sorted(skipped.items(), key=lambda kv: -kv[1])],
         "checks":     all_checks,
-        "summary":    _summarize(all_checks),
+        "summary":    summary,
     }
 
     print(json.dumps(output, indent=2 if args.pretty else None))
-    sys.exit(1 if output["summary"]["errors"] > 0 else 0)
+    sys.exit(1 if summary["errors"] > 0 else 0)
 
 
 if __name__ == "__main__":

--- a/configs/mypy.ini
+++ b/configs/mypy.ini
@@ -1,17 +1,30 @@
 [mypy]
-# JP_TOOLS shared mypy configuration
-python_version = 3.8
-strict = False
+# JP_TOOLS shared mypy configuration.
+#
+# Until 2026-08-14 nothing read this file. run_mypy passed no --config-file, so
+# the only mention of it anywhere was README's config table, and the live gate
+# was mypy's own defaults plus --ignore-missing-imports. Three documented
+# answers to "what does the type gate enforce" and none of them was the real
+# one. It is now passed explicitly, with project-local configs taking
+# precedence.
+#
+# strict, because METHODOLOGY section 2.5 says "mypy strict" and this said
+# False. Same correction as phpstan level 5 to 8, and the same reason: a gate
+# quieter than the manual beside it is worse than either setting alone.
+strict = True
 
-# Practical strictness — catches real bugs without requiring full annotation coverage
-warn_return_any = True
-warn_unused_ignores = True
-warn_redundant_casts = True
-disallow_untyped_defs = False     # flip to True when adding type hints
-check_untyped_defs = True
-ignore_missing_imports = True     # don't fail on third-party stubs
-no_implicit_optional = True
+# No python_version pin. The previous 3.8 predated the 3.12 the CI installs and
+# the code targets, and once this file was actually read that pin would have
+# rejected builtin generics (tuple[Path, str]) already in the codebase.
+# Unpinned, mypy uses the interpreter it runs under.
 
-# Output
+# Third-party stubs are not the project's problem. run_mypy passes
+# --ignore-missing-imports too, so a direct mypy call matches one via check.py.
+ignore_missing_imports = True
+
+# Output. No trailing comments on these values: mypy's ini parser reads
+# "False                    # machine-parseable output" as the literal value
+# and rejects it. That error sat in this file undetected for as long as nothing
+# read it.
 show_error_codes = True
-pretty = False                    # machine-parseable output
+pretty = False

--- a/configs/phpstan.neon
+++ b/configs/phpstan.neon
@@ -1,8 +1,11 @@
 parameters:
-    # JP_TOOLS shared PHPStan config
-    # Start at level 5 — catches real bugs without demanding full type coverage.
-    # Bump toward 9 as the codebase matures.
-    level: 5
+    # JP_TOOLS shared PHPStan config.
+    # Level 8, because METHODOLOGY section 2.5 says level 8 and this file said
+    # 5. A gate quieter than the manual shipped beside it is worse than either
+    # setting on its own: batocera-watch's client/ reported 3 findings at 5 and
+    # 17 at 8, so four fifths of the PHP verdict was missing while the summary
+    # read as authoritative.
+    level: 8
 
     # Don't fail on missing vendor stubs for common frameworks.
     # Add project-specific ignores in a local phpstan.neon that includes this one.

--- a/fix.py
+++ b/fix.py
@@ -12,7 +12,9 @@ import json
 import os
 import shutil
 import subprocess
+from collections.abc import Callable
 from pathlib import Path
+from typing import Any
 
 # One definition of where ruff's config comes from. check.py is import-safe
 # (its argparse sits behind a main guard), so this defers to it rather than
@@ -42,7 +44,7 @@ def _ruff_count(target: str) -> int:
         return 0
 
 
-def fix_ruff(target: str, dry_run: bool, unsafe: bool = False, **_: object) -> dict:
+def fix_ruff(target: str, dry_run: bool, unsafe: bool = False, **_: object) -> dict[str, Any]:
     """Apply ruff's fixes.
 
     `ruff check --fix` applies *safe* fixes only. Most of what accumulates in
@@ -84,7 +86,7 @@ def fix_ruff(target: str, dry_run: bool, unsafe: bool = False, **_: object) -> d
     }
 
 
-def fix_prettier(target: str, dry_run: bool, **_: object) -> dict:
+def fix_prettier(target: str, dry_run: bool, **_: object) -> dict[str, Any]:
     local_bin = Path(__file__).parent / "node_modules" / ".bin"
     cmd = (
         str(local_bin / "prettier.cmd") if (local_bin / "prettier.cmd").exists() else
@@ -122,7 +124,7 @@ def _php_cmd() -> str | None:
     return shutil.which("php") or shutil.which("php.exe")
 
 
-def fix_phpcs(target: str, dry_run: bool, **_: object) -> dict:
+def fix_phpcs(target: str, dry_run: bool, **_: object) -> dict[str, Any]:
     php  = _php_cmd()
     bin_ = _php_bin("phpcbf")
     if not php:
@@ -154,7 +156,7 @@ def fix_phpcs(target: str, dry_run: bool, **_: object) -> dict:
             "output": result.stdout.strip()}
 
 
-def fix_rector(target: str, dry_run: bool, **_: object) -> dict:
+def fix_rector(target: str, dry_run: bool, **_: object) -> dict[str, Any]:
     php  = _php_cmd()
     bin_ = _php_bin("rector")
     if not php:
@@ -179,7 +181,11 @@ def fix_rector(target: str, dry_run: bool, **_: object) -> dict:
                 "note": (result.stderr or result.stdout).strip()[:300]}
 
 
-FIXERS = {
+# Annotated because .get(lang, []) on a bare dict literal infers `object` for
+# the value, and the comprehension in main() then cannot iterate it.
+Fixer = Callable[..., dict[str, Any]]
+
+FIXERS: dict[str, list[tuple[str, Fixer]]] = {
     "python": [("ruff",    fix_ruff)],
     "js":     [("prettier",fix_prettier)],
     "css":    [("prettier",fix_prettier)],
@@ -209,7 +215,7 @@ def _detect_lang(target: str) -> str:
     return "unknown"
 
 
-def main():
+def main() -> None:
     parser = argparse.ArgumentParser(description="Auto-fix code quality issues.")
     parser.add_argument("target", help="File or directory to fix")
     parser.add_argument("--lang",    choices=["python", "js", "css", "php", "auto"], default="auto")

--- a/init-ci.py
+++ b/init-ci.py
@@ -17,7 +17,7 @@ TEMPLATES_DIR = JP_TOOLS_ROOT / "templates"
 METHODOLOGY_DOC = JP_TOOLS_ROOT / "METHODOLOGY.md"
 
 
-def main():
+def main() -> None:
     parser = argparse.ArgumentParser(description="Install JP_TOOLS CI workflow into a repo")
     parser.add_argument("path", nargs="?", default=".",
                         help="Path to git repository (default: cwd)")

--- a/install-hooks.py
+++ b/install-hooks.py
@@ -82,7 +82,7 @@ exit 0
 """
 
 
-def install(repo_path: Path):
+def install(repo_path: Path) -> None:
     git_dir = repo_path / ".git"
     if not git_dir.is_dir():
         print(f"Error: {repo_path} is not a git repository (.git not found)")
@@ -126,7 +126,7 @@ def install(repo_path: Path):
     print(f"Read it: {METHODOLOGY_DOC}")
 
 
-def remove(repo_path: Path):
+def remove(repo_path: Path) -> None:
     hook_file = repo_path / ".git" / "hooks" / "pre-commit"
     if not hook_file.exists():
         print("No pre-commit hook found.")
@@ -156,7 +156,7 @@ def remove(repo_path: Path):
         print(f"Removed JP_TOOLS section from {hook_file} (kept existing hook)")
 
 
-def main():
+def main() -> None:
     parser = argparse.ArgumentParser(description="Install/remove JP_TOOLS pre-commit hook")
     parser.add_argument("path", nargs="?", default=".",
                         help="Path to git repository (default: cwd)")

--- a/tests/test_check_phpstan.py
+++ b/tests/test_check_phpstan.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python
+"""
+JP_TOOLS/tests/test_check_phpstan.py
+Tests check.py's phpstan runner against a real phpstan.
+
+No pytest, no dependencies, same as the rest of tests/.
+
+THE BUG THIS PINS DOWN
+    run_phpstan iterated `data["files"].values()`. phpstan keys that dict BY
+    FILENAME and its per-message objects carry no "file" field, so discarding
+    the key threw away the only copy of the path. `msg.get("file", target)`
+    then fell through to the default on every message, and an entire run
+    reported the target directory as the location:
+
+        /home/joe/projects/batocera-watch:214  Ternary condition always false
+
+    Every finding named the same "file", none of which was a file. Nothing in
+    the summary looked wrong, because the count was right.
+
+    Also asserts the configured level. configs/phpstan.neon shipped `level: 5`
+    while METHODOLOGY section 2.5 said 8, and on one real project that was 3
+    findings reported against 17 present.
+
+Skips rather than fails when the environment cannot support it:
+  - no php                     -> skip
+  - no vendor/bin/phpstan      -> skip (run: composer install in JP_TOOLS)
+
+    python tests/test_check_phpstan.py
+"""
+
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+
+# check.py keeps its argparse behind a main guard, so importing is safe.
+import check  # noqa: E402
+
+# Two findings at level 8, neither of them at level 5: an unspecified iterable
+# value type, and a property with no declared type.
+PHP_AT_LEVEL_8 = """<?php
+class Thing
+{
+    private $items;
+
+    public function take(array $rows): void
+    {
+        $this->items = $rows;
+    }
+}
+"""
+
+fails = 0
+checks = 0
+
+
+def check_(what: str, ok: bool, detail: str = "") -> None:
+    global fails, checks
+    checks += 1
+    if not ok:
+        fails += 1
+    print(f"  [{' ok ' if ok else 'FAIL'}] {what}")
+    if not ok and detail:
+        print(f"         {detail}")
+
+
+def main() -> int:
+    if not shutil.which("php"):
+        print("SKIP: php not found")
+        return 0
+    if not (ROOT / "vendor" / "bin" / "phpstan").exists():
+        print("SKIP: vendor/bin/phpstan not found, run composer install")
+        return 0
+
+    print("Configured level:")
+    cfg = (ROOT / "configs" / "phpstan.neon").read_text(encoding="utf-8")
+    check_("configs/phpstan.neon is at level 8, as METHODOLOGY 2.5 states",
+           "level: 8" in cfg,
+           "; ".join(ln.strip() for ln in cfg.splitlines() if "level" in ln))
+
+    with tempfile.TemporaryDirectory() as td:
+        tmp = Path(td)
+        php_file = tmp / "Thing.php"
+        php_file.write_text(PHP_AT_LEVEL_8, encoding="utf-8")
+
+        result = check.run_phpstan(str(tmp))
+
+        print("\nAgainst a directory holding one failing file:")
+        check_("phpstan ran", result["status"] != "unavailable",
+               str(result.get("note", "")))
+        issues = result["issues"]
+        check_("it found something to report", len(issues) > 0)
+
+        # The bug: every issue's file was the directory that was passed in.
+        named_dir = [i for i in issues if i["file"].rstrip("/") == str(tmp)]
+        check_("no finding is attributed to the target directory",
+               not named_dir,
+               f"{len(named_dir)} of {len(issues)} named {tmp}")
+        check_("every finding names the php file it is in",
+               all(i["file"].endswith("Thing.php") for i in issues),
+               str({i["file"] for i in issues}))
+        check_("every finding carries a real line number",
+               all(isinstance(i["line"], int) and i["line"] > 0 for i in issues),
+               str([i["line"] for i in issues]))
+
+    print(f"\n{checks - fails}/{checks} passed")
+    return 1 if fails else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
METHODOLOGY §2.5 says "PHPStan level 8 / mypy strict". Neither was true of the configs shipped beside it, and one of them was not being read at all.

- `configs/phpstan.neon` said **level 5**. On batocera-watch's `client/` that is 3 findings where level 8 reports **17**.
- `configs/mypy.ini` said `strict = False`, and `run_mypy` passed no `--config-file`. Its only mention anywhere was README's config table. The live gate was mypy's defaults: three documented answers, none of them the real one.
- That file also had `pretty = False   # machine-parseable output`, which mypy's ini parser rejects. Undetected for as long as nothing read it.

**`run_phpstan` lost every filename.** It iterated `data["files"].values()`; phpstan keys that dict *by filename* and its message objects have no `file` field, so `msg.get("file", target)` fell through on every message. A whole run reported `<repo dir>:214` for findings in seven different files. The count was right, so nothing looked wrong.

## Cost of the bump

38 findings in JP_TOOLS' own four CI-checked files, all fixed here. 21 bare generics, 6 missing return annotations, 4 that resolved once those were annotated, 7 substantive — including `check.py` re-indexing `output["summary"]["errors"]` out of a heterogeneous dict literal twice, and `fix.py`'s unannotated `FIXERS` inferring `object`.

`tests/test_check_phpstan.py` pins the filename bug and asserts the level, skipping without php or `vendor/bin/phpstan`. Writing it produced a 39th finding: strict mypy caught a list passed where a str was expected in the test's own detail argument.

Local: gate clean on all four CI files, 3 suites pass (6/6, 12/12, ntfs skips its root-only cases).

Not addressed: `configs/eslint.config.js` is passed to nothing either.