### PR TITLE
check.py: compare against the recorded baseline, in the mode it was recorded

### DIFF
--- a/METHODOLOGY.md
+++ b/METHODOLOGY.md
@@ -287,20 +287,55 @@ of them because they treated adoption as an event rather than a rate.
    then falls as a side effect of doing the work, and no calendar entry is
    required.
 
-   This is also a defect to fix before quoting the toolbox at anything.
-   `install-hooks.py` states in its own docstring that it "runs check.py
-   against staged files", collects them into `$STAGED`, uses that list only to
-   test whether anything was staged at all, and then runs `check.py .` against
+   This was a defect in the toolbox itself, fixed in `9fa6803`.
+   `install-hooks.py` stated in its own docstring that it "runs check.py
+   against staged files", collected them into `$STAGED`, used that list only to
+   test whether anything was staged at all, and then ran `check.py .` against
    the repo root. On greenfield the difference is invisible, because the whole
    tree is clean either way. On anything inherited it is the difference between
    an on-ramp and a wall.
 
-2. **Record the baseline, and hold the line at "no worse".** Ratcheting needs a
-   number to ratchet against. Commit the output of a full run, and have the
-   gate compare against it rather than against zero. Without that stored
-   number, a file that got worse and a file that was always bad are
-   indistinguishable, so no one can tell progress from noise and the effort
-   stops being visible to anyone including you.
+   It is left recorded here rather than deleted, because the same mismatch came
+   straight back through step 2: the hook was fixed to measure per-file while
+   the instruction for recording a baseline still said to measure the whole
+   repo. Fixing one half of a scope mismatch leaves the other half looking
+   correct.
+
+2. **Record the baseline the same way the gate measures, and hold the line at
+   "no worse".** Ratcheting needs a number to ratchet against. Commit a
+   **per-file** run — `check.py --record-baseline` — and have the gate compare
+   against it rather than against zero. Without that stored number, a file that
+   got worse and a file that was always bad are indistinguishable, so no one
+   can tell progress from noise and the effort stops being visible to anyone
+   including you.
+
+   **Per-file, because that is what step 1 made the gate do**, and the two
+   measurements are different quantities in the same units. This sentence used
+   to read "commit the output of a full run", which is how the batocera-watch
+   baseline came to be recorded at the repo root while the hook it had to be
+   compared against ran file by file. The result looked exactly like tool
+   drift: 2472 recorded against 2870 measured, +398 across seven files that
+   nobody had touched since the baseline was taken.
+
+   The signature is worth knowing, because it will happen again to someone.
+   Only the tools that **resolve across files** move between the two modes —
+   `mypy` and `phpstan`. The ones that judge a file in isolation — `ruff`,
+   `phpcs`, `rector` — were byte-identical on every file. If a baseline
+   disagrees with a fresh run on exactly the import-sensitive tools and on
+   nothing else, suspect scope before you suspect versions.
+
+   Note also that "a full run" reads two ways, and both are natural: a run over
+   the full **repo**, and a full run of every **tool** rather than a partial
+   one. Whoever records a baseline tends to read it the first way, which is
+   also the way that produces the larger and more impressive number, and
+   nothing downstream contradicts them. Say per-file, and say why, or it gets
+   helpfully "improved" back.
+
+   A per-file baseline is the **worse** measurement for `mypy` and `phpstan` —
+   in isolation they cannot resolve imports and report more. That is the right
+   trade anyway: the gate can only compare against what it can reproduce, and
+   the excess is real findings rather than noise. On `audit_roms.py` the extra
+   172 were `no-untyped-call` and `no-untyped-def`, not import errors.
 
 3. **Find out which checks are not running before believing the total.** Those
    924 errors covered Python only. `phpstan`, `phpcs` and `rector` all reported

--- a/check.py
+++ b/check.py
@@ -858,7 +858,32 @@ def _per_file_checks(target: str, audit: bool = False) -> list[dict[str, Any]]:
     return checks
 
 
-def record_baseline(target: str, dest: str, audit: bool = False) -> int:
+def _dropped_entries(dest: str, files: dict[str, Any]) -> tuple[list[str], int]:
+    """Files the existing baseline records that this write would not.
+
+    Returns (dropped, existing_count). A destination that does not exist, or
+    cannot be parsed, drops nothing -- there is no prior measurement to lose.
+
+    Recording is whole-file: the doc is rebuilt and rewritten, so pointing two
+    per-file invocations at one path keeps only the second. Both print
+    "recorded 1 file(s)" and the loss surfaces one step later, as the first
+    file failing for being un-baselined -- which reads as a different problem
+    entirely. That is this tool's own failure mode aimed at itself: a zero that
+    means "never measured" wearing the face of a zero that means "measured, and
+    clean".
+    """
+    try:
+        prior = json.loads(Path(dest).read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return [], 0
+    had = prior.get("files")
+    if not isinstance(had, dict):
+        return [], 0
+    return sorted(set(had) - set(files)), len(had)
+
+
+def record_baseline(target: str, dest: str, audit: bool = False,
+                    force: bool = False) -> int:
     root   = _repo_root(target)
     checks = _per_file_checks(target, audit)
     files  = _counts_by_file(checks, root)
@@ -880,11 +905,41 @@ def record_baseline(target: str, dest: str, audit: bool = False) -> int:
         "totals":   _summarize(checks),
         "files":    files,
     }
+    existed = Path(dest).exists()
+    dropped, existing = _dropped_entries(dest, files)
+    if dropped and not force:
+        shown = ", ".join(dropped[:3]) + (f", +{len(dropped) - 3} more"
+                                          if len(dropped) > 3 else "")
+        print(f"baseline: REFUSING to write {dest} -- it records {existing} "
+              f"file(s) and this run measured {len(files)}, so "
+              f"{len(dropped)} would be discarded: {shown}",
+              file=sys.stderr)
+        print("  A discarded file is not baselined, so it fails the next gate "
+              "for having no recorded count -- which looks like a different "
+              "bug one step later.", file=sys.stderr)
+        print(f"  To baseline a whole tree in one go:  "
+              f"check.py <dir> --record-baseline {dest}", file=sys.stderr)
+        print("  To replace the baseline deliberately, including on purpose "
+              "after deleting files:  --force-baseline", file=sys.stderr)
+        return 2
+
     Path(dest).write_text(json.dumps(doc, indent=1, sort_keys=True) + "\n",
                           encoding="utf-8")
     missing = [t for t, s in sorted(status.items()) if s != "pass" and s != "fail"]
     print(f"recorded {len(files)} file(s) from {len(tools)} tool(s), "
           f"mode=per-file, to {dest}")
+    # Say what was displaced. The old message was true about what it wrote and
+    # silent about what it removed, which is exactly why reading it carefully
+    # did not catch the loss.
+    # Keyed on the file having EXISTED, not on how much it recorded. A baseline
+    # of zero files is a real baseline -- every file was clean -- and it is the
+    # one most easily mistaken for no baseline at all, so overwriting it is
+    # exactly when saying so matters.
+    if existed:
+        note = f"  replaced a baseline of {existing} file(s)"
+        if dropped:
+            note += f", discarding {len(dropped)} on --force-baseline"
+        print(note)
     if missing:
         print("  WARNING: recorded while these tools were not running: "
               + ", ".join(f"{t} ({status[t]})" for t in missing))
@@ -990,6 +1045,11 @@ def main() -> None:
                              "Per-file because that is what the gate does; see "
                              "METHODOLOGY, 'Adopting this in a codebase you "
                              "inherited', step 2.")
+    parser.add_argument("--force-baseline", action="store_true",
+                        help="Allow --record-baseline to write a baseline that "
+                             "drops files the existing one recorded. Needed "
+                             "only when that loss is intended, such as after "
+                             "deleting files.")
     args = parser.parse_args()
 
     target = str(Path(args.target).resolve())
@@ -1004,7 +1064,8 @@ def main() -> None:
     # DIFFERENTLY: it runs every file on its own even when handed a directory,
     # which is exactly what `check.py .` does not do.
     if args.record_baseline:
-        sys.exit(record_baseline(target, args.record_baseline, args.audit))
+        sys.exit(record_baseline(target, args.record_baseline, args.audit,
+                                 args.force_baseline))
 
     # ── Single file or explicit --lang / --tools ──────────────────────────
     if not is_dir or args.lang != "auto" or args.tools:

--- a/check.py
+++ b/check.py
@@ -858,11 +858,20 @@ def _per_file_checks(target: str, audit: bool = False) -> list[dict[str, Any]]:
     return checks
 
 
-def _dropped_entries(dest: str, files: dict[str, Any]) -> tuple[list[str], int]:
+def _dropped_entries(dest: str, files: dict[str, Any]) -> tuple[list[str], int, bool]:
     """Files the existing baseline records that this write would not.
 
-    Returns (dropped, existing_count). A destination that does not exist, or
-    cannot be parsed, drops nothing -- there is no prior measurement to lose.
+    Returns (dropped, existing_count, unreadable). A destination that does not
+    exist drops nothing -- there is no prior measurement to lose.
+
+    A destination that exists and CANNOT BE PARSED is a third state and is
+    reported as such, not folded into the first. Raised by batocera-watch
+    re-reviewing this guard, and it is the same overloaded empty the guard
+    exists to fix: a file that fails to parse did hold a measurement -- a
+    truncated write, conflict markers, a half-synced copy over a real baseline
+    -- and its contents are precisely what nobody can recover. Treating it as
+    absent destroys the one case where the prior numbers are unknown, which is
+    the one case where losing them costs most.
 
     Recording is whole-file: the doc is rebuilt and rewritten, so pointing two
     per-file invocations at one path keeps only the second. Both print
@@ -872,14 +881,18 @@ def _dropped_entries(dest: str, files: dict[str, Any]) -> tuple[list[str], int]:
     means "never measured" wearing the face of a zero that means "measured, and
     clean".
     """
+    if not Path(dest).exists():
+        return [], 0, False
     try:
         prior = json.loads(Path(dest).read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError):
-        return [], 0
+        return [], 0, True
     had = prior.get("files")
     if not isinstance(had, dict):
-        return [], 0
-    return sorted(set(had) - set(files)), len(had)
+        # Parsed, but not a baseline this tool wrote. Same argument: something
+        # is there, and this run cannot say what it was worth.
+        return [], 0, True
+    return sorted(set(had) - set(files)), len(had), False
 
 
 def record_baseline(target: str, dest: str, audit: bool = False,
@@ -906,7 +919,18 @@ def record_baseline(target: str, dest: str, audit: bool = False,
         "files":    files,
     }
     existed = Path(dest).exists()
-    dropped, existing = _dropped_entries(dest, files)
+    dropped, existing, unreadable = _dropped_entries(dest, files)
+    if unreadable and not force:
+        print(f"baseline: REFUSING to write {dest} -- it exists but cannot be "
+              f"read as a baseline, so this run cannot say what would be lost.",
+              file=sys.stderr)
+        print("  That is a reason to stop, not to proceed: a truncated write, "
+              "conflict markers or a half-synced file all look like this, and "
+              "the numbers in it are the ones nobody can reconstruct.",
+              file=sys.stderr)
+        print("  Inspect it, or overwrite deliberately with --force-baseline.",
+              file=sys.stderr)
+        return 2
     if dropped and not force:
         shown = ", ".join(dropped[:3]) + (f", +{len(dropped) - 3} more"
                                           if len(dropped) > 3 else "")

--- a/check.py
+++ b/check.py
@@ -20,6 +20,7 @@ import re
 import shutil
 import subprocess
 import sys
+import time
 from pathlib import Path
 from typing import Any
 
@@ -727,6 +728,237 @@ def _summarize(checks: list[dict[str, Any]]) -> dict[str, Any]:
     }
 
 
+# ── baseline ──────────────────────────────────────────────────────────────────
+#
+# A baseline is a stored per-file, per-tool count the gate compares against
+# instead of comparing against zero. Three things about it are load-bearing, and
+# all three were measured on batocera-watch on 2026-08-15 rather than reasoned:
+#
+# MODE. A baseline must be measured the way the gate measures. That repo's was
+# recorded with a whole-repo run while the hook checks staged files one at a
+# time, and the two disagreed by +398 errors across seven files nobody had
+# touched since a week before. Only the tools that resolve ACROSS files moved --
+# mypy and phpstan -- while ruff, phpcs and rector were byte-identical on every
+# file. That partition is the signature of scope, not of drift, and it is why
+# the mode is recorded here and a mismatch is REFUSED rather than compared.
+# METHODOLOGY step 2 mandated the mismatch until this landed: it said to commit
+# "the output of a full run", which reads as whole-repo to most people.
+#
+# TOOLS THAT DID NOT RUN. An unavailable tool reports zero issues. That reads as
+# an improvement, lets a real regression through, and then bakes a false zero
+# into the next re-record, after which the true count reads as a regression. A
+# tool that is unavailable now, or whose version differs from the recording, is
+# reported as "cannot compare" and excluded from the verdict. Never counted as
+# zero, never silently passed. This is METHODOLOGY step 3 applied to the
+# baseline itself: a check that did not run looks exactly like one that passed.
+#
+# VERSIONS DEGRADE, THEY DO NOT REFUSE. Compare only when BOTH sides are known.
+# An unknown version is not evidence of a match, but refusing on one would make
+# the feature unusable wherever a tool has no version we can parse -- and a
+# guard that fires on "cannot tell" gets switched off, which is the reasoning
+# coord.py already uses for session ownership.
+#
+# The verdict is on ERRORS, because that is what the gate already exits on.
+# Warnings are recorded per file so a later change can use them, and are printed
+# in the report, but they do not fail a commit that errors would not fail.
+
+BASELINE_VERSION = 1
+
+_VERSION_CMD = {
+    "ruff":      ["ruff", "--version"],
+    "mypy":      ["mypy", "--version"],
+    "eslint":    ["eslint", "--version"],
+    "stylelint": ["stylelint", "--version"],
+    "prettier":  ["prettier", "--version"],
+    "cppcheck":  ["cppcheck", "--version"],
+}
+_VERSION_RE = re.compile(r"\d+\.\d+(?:\.\d+)?")
+
+
+def _tool_version(name: str) -> str:
+    """Best-effort version string, or "" meaning "cannot tell"."""
+    cmd = _VERSION_CMD.get(name)
+    if not cmd or not shutil.which(cmd[0]):
+        return ""
+    try:
+        r = subprocess.run(cmd, capture_output=True, text=True,
+                           check=False, timeout=30)
+    except (OSError, subprocess.SubprocessError):
+        return ""
+    m = _VERSION_RE.search(f"{r.stdout} {r.stderr}")
+    return m.group(0) if m else ""
+
+
+def _repo_root(target: str) -> Path:
+    """What baseline paths are relative to.
+
+    Git toplevel where there is one, so a file is the same key no matter which
+    directory the gate ran from. Keyed on absolute paths a baseline is useless
+    on any other machine; keyed on cwd-relative ones it silently changes meaning
+    when the hook runs from a subdirectory.
+    """
+    p = Path(target).resolve()
+    start = p if p.is_dir() else p.parent
+    try:
+        r = subprocess.run(
+            ["git", "-C", str(start), "rev-parse", "--show-toplevel"],
+            capture_output=True, text=True, check=False, timeout=30)
+        if r.returncode == 0 and r.stdout.strip():
+            return Path(r.stdout.strip())
+    except (OSError, subprocess.SubprocessError):
+        pass
+    return start
+
+
+def _rel(path_str: str, root: Path) -> str:
+    try:
+        return Path(path_str).resolve().relative_to(root).as_posix()
+    except (ValueError, OSError):
+        return Path(path_str).as_posix()
+
+
+def _counts_by_file(checks: list[dict[str, Any]], root: Path) -> dict[str, Any]:
+    """{path: {tool: {"errors": n, "warnings": n}}} for one run."""
+    out: dict[str, Any] = {}
+    for c in checks:
+        tool = c.get("tool", "?")
+        for i in c.get("issues", []):
+            slot = out.setdefault(_rel(i.get("file", ""), root), {})
+            counts = slot.setdefault(tool, {"errors": 0, "warnings": 0})
+            counts["errors" if i.get("severity") == "error" else "warnings"] += 1
+    return out
+
+
+def _statuses(checks: list[dict[str, Any]]) -> dict[str, str]:
+    return {c.get("tool", "?"): c.get("status", "unknown") for c in checks}
+
+
+def _per_file_checks(target: str, audit: bool = False) -> list[dict[str, Any]]:
+    """Run the measurement the GATE performs: every file on its own.
+
+    Deliberately not `check.py .`. The entire point of the mode field is that
+    the two produce different numbers, so a recorder taking the cheaper
+    whole-repo route would record exactly the quantity the gate cannot
+    reproduce -- which is the bug this feature exists to remove.
+    """
+    p = Path(target)
+    if p.is_file():
+        files = [str(p)]
+    else:
+        groups, _ = _collect_files(str(p))
+        files = sorted(f for fs in groups.values() for f in fs)
+    checks: list[dict[str, Any]] = []
+    for f in files:
+        lang = _detect_lang(f)
+        names = list(DEFAULT_TOOLS.get(lang, []))
+        if audit:
+            names.extend(AUDIT_TOOLS.get(lang, []))
+        if names:
+            checks.extend(_run_tools(names, f))
+    return checks
+
+
+def record_baseline(target: str, dest: str, audit: bool = False) -> int:
+    root   = _repo_root(target)
+    checks = _per_file_checks(target, audit)
+    files  = _counts_by_file(checks, root)
+    tools  = sorted({c.get("tool", "?") for c in checks})
+    status = _statuses(checks)
+    doc = {
+        "baseline_version": BASELINE_VERSION,
+        "mode":     "per-file",
+        "recorded": time.strftime("%Y-%m-%d"),
+        "root":     root.name,
+        # Recorded so a later run can refuse to compare numbers that two
+        # different tools produced. "" means the version could not be
+        # established, which downstream treats as "cannot tell", not "same".
+        "tools":    {t: _tool_version(t) for t in tools},
+        # A tool that was unavailable WHEN RECORDED contributed zero, and that
+        # zero is not a measurement. Keeping the status makes it visible rather
+        # than letting it read as a clean file.
+        "status":   status,
+        "totals":   _summarize(checks),
+        "files":    files,
+    }
+    Path(dest).write_text(json.dumps(doc, indent=1, sort_keys=True) + "\n",
+                          encoding="utf-8")
+    missing = [t for t, s in sorted(status.items()) if s != "pass" and s != "fail"]
+    print(f"recorded {len(files)} file(s) from {len(tools)} tool(s), "
+          f"mode=per-file, to {dest}")
+    if missing:
+        print("  WARNING: recorded while these tools were not running: "
+              + ", ".join(f"{t} ({status[t]})" for t in missing))
+        print("  Their zeros are not measurements. Re-record where they run, "
+              "or a later real count will read as a regression.")
+    return 0
+
+
+def compare_baseline(checks: list[dict[str, Any]], target: str,
+                     source: str, mode: str) -> int:
+    """0 = no worse, 1 = worse, 2 = cannot compare."""
+    try:
+        doc = json.loads(Path(source).read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"baseline: cannot read {source}: {exc}", file=sys.stderr)
+        return 2
+
+    recorded_mode = doc.get("mode", "unknown")
+    if recorded_mode != mode:
+        print(f"baseline: REFUSING to compare. It was recorded as "
+              f"mode={recorded_mode!r} and this run is {mode!r}. Those are "
+              f"different quantities in the same units -- for any tool that "
+              f"resolves across files they disagree by hundreds of findings on "
+              f"unchanged code. Re-record with --record-baseline.",
+              file=sys.stderr)
+        return 2
+
+    root   = _repo_root(target)
+    now    = _counts_by_file(checks, root)
+    was    = doc.get("files", {})
+    old_v  = doc.get("tools", {})
+    status = _statuses(checks)
+
+    skipped: list[tuple[str, str]] = []
+    for tool, st in sorted(status.items()):
+        if st not in ("pass", "fail"):
+            skipped.append((tool, f"did not run ({st})"))
+            continue
+        was_v, now_v = old_v.get(tool, ""), _tool_version(tool)
+        if was_v and now_v and was_v != now_v:
+            skipped.append((tool, f"version {was_v} -> {now_v}"))
+    skip = {t for t, _ in skipped}
+
+    worse, deltas = [], []
+    for path in sorted(set(now) | set(was)):
+        tools = set(now.get(path, {})) | set(was.get(path, {}))
+        for tool in sorted(tools - skip):
+            before = int(was.get(path, {}).get(tool, {}).get("errors", 0))
+            after  = int(now.get(path, {}).get(tool, {}).get("errors", 0))
+            if after != before:
+                deltas.append(f"  {path}  {tool}  {before} -> {after} "
+                              f"({after - before:+d})")
+            if after > before:
+                worse.append((path, tool, before, after))
+
+    for tool, why in skipped:
+        print(f"baseline: cannot compare {tool} -- {why}. Excluded from the "
+              f"verdict rather than counted as zero.", file=sys.stderr)
+    for line in deltas:
+        print(line)
+    if not deltas:
+        # Say it. A ratchet that only speaks when it fails is indistinguishable
+        # from one that never ran, which is the whole complaint in step 3.
+        print(f"baseline: no change against {Path(source).name}")
+
+    if worse:
+        print("", file=sys.stderr)
+        print("baseline: WORSE than recorded --", file=sys.stderr)
+        for path, tool, before, after in worse:
+            print(f"  {path}  {tool}  {before} -> {after}", file=sys.stderr)
+        return 1
+    return 0
+
+
 # ── main ──────────────────────────────────────────────────────────────────────
 
 def main() -> None:
@@ -748,6 +980,16 @@ def main() -> None:
                              "instead of 2. For callers handed an arbitrary file "
                              "list (the pre-commit hook), where a README is not "
                              "a failure.")
+    parser.add_argument("--baseline", metavar="FILE",
+                        help="Compare against a recorded baseline and fail only "
+                             "where a file got WORSE, instead of failing on any "
+                             "finding at all. Refuses if the baseline was "
+                             "recorded in a different mode.")
+    parser.add_argument("--record-baseline", metavar="FILE",
+                        help="Measure per-file and write a baseline to FILE. "
+                             "Per-file because that is what the gate does; see "
+                             "METHODOLOGY, 'Adopting this in a codebase you "
+                             "inherited', step 2.")
     args = parser.parse_args()
 
     target = str(Path(args.target).resolve())
@@ -756,6 +998,13 @@ def main() -> None:
         sys.exit(2)
 
     is_dir = Path(target).is_dir()
+
+    # ── Record a baseline and stop ────────────────────────────────────────
+    # Its own path, before the normal flow, because recording MEASURES
+    # DIFFERENTLY: it runs every file on its own even when handed a directory,
+    # which is exactly what `check.py .` does not do.
+    if args.record_baseline:
+        sys.exit(record_baseline(target, args.record_baseline, args.audit))
 
     # ── Single file or explicit --lang / --tools ──────────────────────────
     if not is_dir or args.lang != "auto" or args.tools:
@@ -786,6 +1035,10 @@ def main() -> None:
             "summary":  summary,
         }
         print(json.dumps(output, indent=2 if args.pretty else None))
+        # A single file IS the per-file measurement, so a per-file baseline is
+        # comparable here and the verdict replaces the compare-against-zero one.
+        if args.baseline:
+            sys.exit(compare_baseline(checks, target, args.baseline, "per-file"))
         sys.exit(1 if summary["errors"] > 0 else 0)
 
     # ── Directory: scan, group by language, run appropriate tools ─────────
@@ -848,6 +1101,11 @@ def main() -> None:
     }
 
     print(json.dumps(output, indent=2 if args.pretty else None))
+    # A directory run lets the dir-capable tools resolve across files, so this
+    # is the WHOLE-REPO measurement. Declaring it as such is what makes
+    # compare_baseline refuse rather than report scope as regression.
+    if args.baseline:
+        sys.exit(compare_baseline(all_checks, target, args.baseline, "whole-repo"))
     sys.exit(1 if summary["errors"] > 0 else 0)
 
 

--- a/tests/test_check_baseline.py
+++ b/tests/test_check_baseline.py
@@ -188,6 +188,38 @@ def main() -> int:
         check("  and says what it replaced, which the old message never did",
               "replaced a baseline of" in r.stdout, r.stdout)
 
+        # Raised by batocera-watch re-reviewing the guard above. "Cannot parse"
+        # was folded into "does not exist", so a corrupt baseline -- a
+        # truncated write, conflict markers, a half-synced copy -- was
+        # overwritten at exit 0 with nothing said. It is the one case where the
+        # prior numbers cannot be reconstructed, which makes it the worst one
+        # to discard quietly.
+        print("an unparseable baseline is not an absent one")
+        broken = str(Path(repo) / "broken.json")
+        Path(broken).write_text("{ this is not json", encoding="utf-8")
+        r = run("dirty.py", "--record-baseline", broken, cwd=repo)
+        check("recording over an unparseable baseline REFUSES",
+              r.returncode == 2, f"exit {r.returncode}: {r.stdout}{r.stderr}")
+        check("  and says it cannot tell what would be lost",
+              "cannot be read as a baseline" in r.stderr, r.stderr)
+        check("  and leaves the unreadable file untouched for a human",
+              Path(broken).read_text(encoding="utf-8") == "{ this is not json",
+              Path(broken).read_text(encoding="utf-8")[:60])
+        r = run("dirty.py", "--record-baseline", broken, "--force-baseline",
+                cwd=repo)
+        check("  --force-baseline still overwrites it deliberately",
+              r.returncode == 0, r.stderr)
+        check("  and the overwrite really happened",
+              "dirty.py" in json.loads(Path(broken).read_text(encoding="utf-8"))
+              .get("files", {}))
+
+        print("valid JSON that is not a baseline is also refused")
+        alien = str(Path(repo) / "alien.json")
+        Path(alien).write_text('{"something": "else"}', encoding="utf-8")
+        r = run("dirty.py", "--record-baseline", alien, cwd=repo)
+        check("a parseable non-baseline is refused too", r.returncode == 2,
+              f"exit {r.returncode}: {r.stdout}{r.stderr}")
+
         print("a repo with no baseline behaves exactly as before")
         (Path(repo) / "dirty.py").write_text(DIRTY, encoding="utf-8")
         r = run("dirty.py", cwd=repo)

--- a/tests/test_check_baseline.py
+++ b/tests/test_check_baseline.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python
+"""
+JP_TOOLS/tests/test_check_baseline.py
+Drives `check.py --record-baseline` and `check.py --baseline` against real
+throwaway git repos and real ruff runs. No pytest, no dependencies -- the
+toolbox has none and this is not going to add the first.
+
+THE BUG THIS PINS DOWN
+    A gate with no baseline compares every staged file against ZERO, so on an
+    inherited repo the on-ramp is still a wall: you meet the bar in one move or
+    you do not commit. METHODOLOGY, "Adopting this in a codebase you inherited",
+    step 2, said to record one and compare against it. Nothing did.
+
+    Worse, the recording half was ALSO wrong, and in a way that reads as a tool
+    problem rather than a method problem. Step 2 said to commit "the output of a
+    full run", which everyone reads as the whole repo, while step 1 had already
+    made the gate check staged files one at a time. Measured on batocera-watch
+    2026-08-15: 2472 errors recorded against 2870 measured, +398 across seven
+    files whose code had not changed in a week.
+
+    The signature is what makes it diagnosable. Only the tools that resolve
+    ACROSS files moved -- mypy and phpstan. ruff, phpcs and rector judge a file
+    in isolation and were byte-identical on every single file. Scope, not drift.
+
+    So mode is recorded, and a mismatch is refused rather than compared. A
+    ratchet that reports scope as regression is worse than no ratchet: it
+    accuses you of breaking seven files you never opened.
+
+Skips rather than fails when the environment cannot support it:
+  - no git   -> skip
+  - no ruff  -> skip (nothing can produce a countable finding)
+
+    python tests/test_check_baseline.py
+"""
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT  = Path(__file__).resolve().parent.parent
+CHECK = ROOT / "check.py"
+
+DIRTY = "import os\nimport sys\nx = 1\n"       # ruff: unused imports
+WORSE = "import os\nimport sys\nimport json\nx = 1\n"
+CLEAN = "x = 1\n"
+
+fails = 0
+checks = 0
+
+
+def check(what: str, ok: bool, detail: str = "") -> None:
+    global fails, checks
+    checks += 1
+    if not ok:
+        fails += 1
+    print(f"  [{' ok ' if ok else 'FAIL'}] {what}")
+    if not ok and detail:
+        print(f"         {detail}")
+
+
+def run(*args: str, cwd: str) -> subprocess.CompletedProcess:
+    return subprocess.run([sys.executable, str(CHECK), *args],
+                          capture_output=True, text=True, check=False, cwd=cwd)
+
+
+def make_repo(tmp: str) -> str:
+    repo = Path(tmp) / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q", "."], cwd=str(repo), check=True)
+    (repo / "dirty.py").write_text(DIRTY, encoding="utf-8")
+    (repo / "clean.py").write_text(CLEAN, encoding="utf-8")
+    return str(repo)
+
+
+def main() -> int:
+    if not shutil.which("git"):
+        print("SKIP: git not found")
+        return 0
+    if not shutil.which("ruff"):
+        print("SKIP: ruff not found -- nothing can produce a countable finding")
+        return 0
+
+    with tempfile.TemporaryDirectory() as tmp:
+        repo = make_repo(tmp)
+        base = str(Path(repo) / "base.json")
+
+        print("recording")
+        r = run(".", "--record-baseline", base, cwd=repo)
+        check("record exits 0", r.returncode == 0, r.stderr)
+        doc = json.loads(Path(base).read_text(encoding="utf-8"))
+
+        # The whole point. A baseline that does not say how it was measured
+        # cannot be compared safely, because the two modes disagree by
+        # hundreds of findings on identical code.
+        check("records mode=per-file", doc.get("mode") == "per-file",
+              f"got {doc.get('mode')!r}")
+        check("records the tool versions it used",
+              isinstance(doc.get("tools"), dict) and "ruff" in doc["tools"])
+        check("records per-tool status, so a tool that did not run stays visible",
+              isinstance(doc.get("status"), dict))
+        check("keys files relative to the repo root, not absolutely",
+              "dirty.py" in doc.get("files", {}),
+              f"got keys {list(doc.get('files', {}))}")
+        check("a file with no findings is simply absent",
+              "clean.py" not in doc.get("files", {}))
+
+        print("the three acceptance cases")
+        # 1. An edit that leaves the count unchanged must commit.
+        (Path(repo) / "dirty.py").write_text(DIRTY + "z = 3\n", encoding="utf-8")
+        r = run("dirty.py", "--baseline", base, cwd=repo)
+        check("unchanged count exits 0", r.returncode == 0, r.stderr)
+
+        # 2. An edit that raises it is refused, naming the file and BOTH numbers.
+        (Path(repo) / "dirty.py").write_text(WORSE, encoding="utf-8")
+        r = run("dirty.py", "--baseline", base, cwd=repo)
+        check("a raised count exits 1", r.returncode == 1)
+        check("the refusal names the file", "dirty.py" in r.stderr, r.stderr)
+        check("the refusal names both numbers", "3 -> 4" in r.stderr, r.stderr)
+
+        # 3. An edit that lowers it commits, and the gain is visible.
+        (Path(repo) / "dirty.py").write_text(CLEAN, encoding="utf-8")
+        r = run("dirty.py", "--baseline", base, cwd=repo)
+        check("a lowered count exits 0", r.returncode == 0, r.stderr)
+        check("the gain is reported, not silently accepted",
+              "-3" in r.stdout, r.stdout)
+
+        print("mode enforcement")
+        (Path(repo) / "dirty.py").write_text(DIRTY, encoding="utf-8")
+        r = run(".", "--baseline", base, cwd=repo)
+        check("a whole-repo run against a per-file baseline REFUSES",
+              r.returncode == 2, f"exit {r.returncode}")
+        check("and says which two modes disagree",
+              "per-file" in r.stderr and "whole-repo" in r.stderr, r.stderr)
+
+        print("a tool that cannot be compared is never counted as zero")
+        doc = json.loads(Path(base).read_text(encoding="utf-8"))
+        doc["tools"]["ruff"] = "0.0.1-not-a-real-version"
+        Path(base).write_text(json.dumps(doc), encoding="utf-8")
+        (Path(repo) / "dirty.py").write_text(WORSE, encoding="utf-8")
+        r = run("dirty.py", "--baseline", base, cwd=repo)
+        # Genuinely worse, but under a different ruff -- so the honest answer is
+        # "cannot tell", not "regression" and not "pass".
+        check("a version mismatch excludes that tool instead of failing",
+              r.returncode == 0, f"exit {r.returncode}")
+        check("and says so out loud rather than silently passing",
+              "cannot compare ruff" in r.stderr, r.stderr)
+
+        print("a repo with no baseline behaves exactly as before")
+        (Path(repo) / "dirty.py").write_text(DIRTY, encoding="utf-8")
+        r = run("dirty.py", cwd=repo)
+        check("dirty file with no --baseline still exits 1", r.returncode == 1)
+        r = run("clean.py", cwd=repo)
+        check("clean file with no --baseline still exits 0", r.returncode == 0,
+              r.stderr)
+
+    print()
+    print(f"{checks - fails}/{checks} passed")
+    return 1 if fails else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_check_baseline.py
+++ b/tests/test_check_baseline.py
@@ -149,6 +149,45 @@ def main() -> int:
         check("and says so out loud rather than silently passing",
               "cannot compare ruff" in r.stderr, r.stderr)
 
+        # Reported by batocera-watch reviewing PR #32. Recording rebuilds the
+        # whole document, so two per-file invocations at one path kept only the
+        # second -- and BOTH printed "recorded 1 file(s)". The loss surfaced a
+        # step later as the first file failing for having no recorded count,
+        # which reads as an unrelated bug. Pinning the refusal AND the
+        # untouched file, because a guard that refuses after corrupting the
+        # destination has not helped anyone.
+        print("recording a second file must not silently discard the first")
+        narrow = str(Path(repo) / "narrow.json")
+        r = run("dirty.py", "--record-baseline", narrow, cwd=repo)
+        check("recording one file exits 0", r.returncode == 0, r.stderr)
+        r = run("clean.py", "--record-baseline", narrow, cwd=repo)
+        check("recording a second file over it REFUSES", r.returncode == 2,
+              f"exit {r.returncode}: {r.stdout}{r.stderr}")
+        check("  and names the file that would be lost",
+              "dirty.py" in r.stderr, r.stderr)
+        check("  and points at the whole-directory path that works",
+              "--record-baseline" in r.stderr and "<dir>" in r.stderr, r.stderr)
+        doc = json.loads(Path(narrow).read_text(encoding="utf-8"))
+        check("  and leaves the existing baseline intact",
+              "dirty.py" in doc.get("files", {}), sorted(doc.get("files", {})))
+
+        print("the loss is allowed when it is asked for, and said out loud")
+        r = run("clean.py", "--record-baseline", narrow, "--force-baseline",
+                cwd=repo)
+        check("--force-baseline writes it", r.returncode == 0, r.stderr)
+        check("  and reports what it discarded rather than just what it wrote",
+              "discarding" in r.stdout, r.stdout)
+        doc = json.loads(Path(narrow).read_text(encoding="utf-8"))
+        check("  and the discard really happened",
+              "dirty.py" not in doc.get("files", {}), sorted(doc.get("files", {})))
+
+        print("widening an existing baseline is not a discard and is not refused")
+        r = run(".", "--record-baseline", narrow, cwd=repo)
+        check("recording the whole tree over a narrower baseline exits 0",
+              r.returncode == 0, r.stderr)
+        check("  and says what it replaced, which the old message never did",
+              "replaced a baseline of" in r.stdout, r.stdout)
+
         print("a repo with no baseline behaves exactly as before")
         (Path(repo) / "dirty.py").write_text(DIRTY, encoding="utf-8")
         r = run("dirty.py", cwd=repo)


### PR DESCRIPTION
Closes #31.

METHODOLOGY has said since it was written to record a baseline and have the gate compare against it rather than against zero. Nothing did — `grep -n baseline check.py` returned nothing — so a staged file in an inherited repo still had to reach zero in one move, which is the wall the section exists to avoid.

## The half that is not obvious

**The number has to be measured the way the gate measures.** Step 2 said to commit *"the output of a full run"*, which reads as the whole repo, while step 1 had already made the gate check staged files one at a time.

Measured on batocera-watch: **2472 errors recorded, 2870 today, +398 across seven files whose code had not changed in a week.** Two wrong causes were proposed and refuted before the real one — not the host (same box), and not tool drift (`mypy 2.3.0` and `ruff 0.16.1` were installed two days *before* the baseline and untouched since, and `check.py` is deterministic across four runs including one with `.mypy_cache` purged).

The signature is what makes it diagnosable, and it is worth knowing because it will happen to someone else:

```
audit_roms       mypy   base 145   whole 145   perfile 187
wine_install_ui  mypy   base  60   whole  60   perfile 160
bw.php        phpstan   base   3   whole   3   perfile  30
ruff / phpcs / rector:  identical in all three columns, every file
```

Only the tools that resolve **across** files move between the two modes. The three that judge a file in isolation are byte-identical. That is scope, not drift — confirmed 21 of 21 exact matches.

So the baseline was not recorded carelessly. **It was recorded exactly as written**, which is why this PR changes the document as well as the tool.

## What this adds

- **`--record-baseline FILE`** measures **per file even when handed a directory**, and stores the mode, per-tool versions and each tool's status alongside the counts.
- **`--baseline FILE`** fails only where a file got worse, and **refuses outright** when the recorded mode is not the mode being run.
- A tool that **did not run**, or whose **version changed**, is excluded from the verdict and said out loud — never counted as zero. Zero from a tool that never ran reads as an improvement, lets a real regression through, and bakes a false zero into the next re-record, after which the true count reads as a regression. That is step 3 happening to the baseline itself. Recording warns too, so a baseline taken on a box missing PHP cannot quietly enshrine zeros.
- Versions **degrade rather than refuse** — compared only when both sides are known, because a guard that fires on "cannot tell" gets switched off. Same reasoning `coord.py` uses for session ownership.
- The verdict is on **errors**, matching the exit rule the gate already had. Warnings are recorded and printed but do not fail a commit that errors would not.

## Documentation

METHODOLOGY step 2 now says per-file **and says why**, including that "a full run" reads equally as whole-repo and as all-tools — and that the whole-repo reading also produces the larger, more impressive number, so nothing downstream contradicts whoever picks it.

Step 1's paragraph moves from present to past tense: it still described the `check.py .` defect that `9fa6803` fixed. It is kept rather than deleted, because fixing one half of a scope mismatch is precisely what left the other half looking correct.

## Verification

18 tests, driving the real CLI against real git repos and real `ruff` runs, covering all four acceptance criteria from #31 plus mode refusal and the cannot-compare rule.

Each was checked for discrimination by reverting the behaviour it pins, because a test that passes with the fix reverted proves nothing:

| mutation | result |
|---|---|
| disable the mode refusal | 16/18 |
| disable version exclusion | 16/18 |
| stop detecting a worse file | 15/18 |
| record the wrong mode | 7/18 |
| *(unmodified)* | **18/18** |

The real gate is clean on the changed file (`ruff` and `mypy` both pass), and the existing suite is unaffected — 12/12 `test_install_hooks`, 11 checks in `test_ntfs_recovery`, `test_check_phpstan` skips without vendor.

## Not in this change

batocera-watch's baseline needs re-recording per-file regardless of anything here, because it never measured what the hook measures. Expect roughly **+398**, and that is not a regression — the excess is genuine (`no-untyped-call` 121, `no-untyped-def` 51 on `audit_roms`), not import noise.

Separately: `ruff` and `mypy` have no version floor anywhere in this repo — no `requirements.txt`, no `pyproject`, `check.py` just `shutil.which`es them. Stamping records drift; pinning prevents it. That is its own change.
